### PR TITLE
Type deduction improvements, reference semantic fixes, ...

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,14 @@
+* v0.1.3
+- improve type deduction capabilities for infix nodes
+- add overload for =drop= that doesn't just work on a mutable data
+  frame
+- fix reference semantics issues if DF is modified and visible in
+  result (only data is shared, but columns should be respected)
+- =arrange= now also takes a =varargs[string]= instead of a
+  =seq=. While there is still a bug of not properly being able to use
+  varargs, at least an array is possible (and hopefully at some point
+  proper varargs).  
+
 * v0.1.2
 - CSV parser is more robust, can handle unnammed columns
 - explicit types in =idx=, =col= column reference finally works

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -96,6 +96,12 @@ proc drop*(df: var DataFrame, key: string) {.inline.} =
   ## drops the given key from the DataFrame
   df.data.del(key)
 
+proc drop*(df: DataFrame, keys: varargs[string]): DataFrame =
+  ## Returns a `DataFrame` with the given keys dropped.
+  result = df.shallowCopy()
+  for k in keys:
+    result.drop(k)
+
 #proc add*(v: PersistentVector[Value], w: PersistentVector[Value]): PersistentVector[Value] =
 #  ## adds all elements of `w` to `v` and returns the resulting vector
 #  if v.len > 100 or w.len > 100:

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -626,7 +626,7 @@ proc buildColHashes(df: DataFrame, keys: seq[string]): seq[Hash] =
   # finalize the hashes
   result.applyIt(!$it)
 
-proc arrange*(df: DataFrame, by: seq[string], order = SortOrder.Ascending): DataFrame
+proc arrange*(df: DataFrame, by: varargs[string], order = SortOrder.Ascending): DataFrame
 iterator groups*(df: DataFrame, order = SortOrder.Ascending): (seq[(string, Value)], DataFrame) =
   ## yields the subgroups of a grouped DataFrame `df` and the `(key, Value)`
   ## pairs that were used to create the subgroup. If `df` has more than
@@ -1033,12 +1033,12 @@ proc sortBys(df: DataFrame, by: seq[string], order: SortOrder): seq[int] =
       resIdx = sortRecurse(df, by, startIdx = 1, resIdx = resIdx, order = order)
     result = resIdx
 
-proc arrange*(df: DataFrame, by: seq[string], order = SortOrder.Ascending): DataFrame =
+proc arrange*(df: DataFrame, by: varargs[string], order = SortOrder.Ascending): DataFrame =
   ## sorts the data frame in ascending / descending `order` by key `by`
   # now sort by cols in ascending order of each col, i.e. ties will be broken
   # in ascending order of the columns
   result = newDataFrame(df.ncols)
-  let idxCol = sortBys(df, by, order = order)
+  let idxCol = sortBys(df, @by, order = order)
   result.len = df.len
   var data = newColumn()
   for k in keys(df):

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -687,7 +687,15 @@ proc getTypeIfPureTree(tab: Table[string, NimNode], n: NimNode, numArgs: int): P
     ## Needed in some cases like dotExpressions from an infix so that we know
     ## the result of the full expression
     if n.len > 0:
-      result = tab.getTypeIfPureTree(n[^1], numArgs)
+      case n.kind
+      of nnkInfix, nnkCall, nnkPrefix, nnkCommand: # type we need is of 0 arg
+        result = tab.getTypeIfPureTree(n[0], numArgs)
+      of nnkDotExpr: # type we need is of last arg
+        result = tab.getTypeIfPureTree(n[^1], numArgs)
+      else:
+        # else we have no type info?
+        #result = tab.getTypeIfPureTree(n[^1], numArgs)
+        return
 
   ## TODO: there are cases where one can extract type information from impure trees.
   ## `idx("a").float` is a nnkDotExpr that is impure, but let's us know that the output

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -389,7 +389,6 @@ suite "Data frame tests":
     # which is the case for current grouping and the mpg dataset:
     check subGroupCount == 19
 
-
     let cylFiltered = mpg.filter(f{c"cyl" == 4})
     check cylFiltered.len == 81
     let cylDrvFiltered = cylFiltered.filter(f{c"drv" == "4"})

--- a/tests/testsFormula.nim
+++ b/tests/testsFormula.nim
@@ -235,3 +235,13 @@ suite "Formulas":
         else:
           idx("b", int)) }
       check fn.evaluate(df).iCol == [1, 4, 5].toTensor
+
+  test "Add with integer should produce integer":
+    let fn = f{"a+5" ~ `a` + 5 }
+    check fn.evaluate(df).kind == colInt
+    check fn.evaluate(df).iCol == [6, 7, 8].toTensor
+
+  test "Add with float should produce float":
+    let fn = f{"a+5.0" ~ `a` + 5.0 }
+    check fn.evaluate(df).kind == colFloat
+    check fn.evaluate(df).fCol == [6.0, 7.0, 8.0].toTensor


### PR DESCRIPTION
Mainly improves the type deduction of formulas for things like:
```nim
f{`a` + 5}
f{`a` + 5.0}
```
where the type of the input column will be determined from the type of the literal (or local symbol). 

While this causes the old "be careful to write a float" issue, it's better than a compile time error, because the input is determined to be integer, but the result is expected float.

We can play around with ideas to force floats in these cases, but I'm probably in favor of telling people to be specific...

On the other hand fixes some issues with reference semantics of procedures that should return a copy, but didn't really. We're still dealing with reference semantics, so overwriting a column *will* still modify the input in case of a `mutate` call.

But something like:
```nim
# let df be a DF with cols "x", "y", "z"
echo df.mutate(f{"x+y" ~ `x` + `y`})
echo df.filter(f{`z` + 5})
```
should *not* have the column `x+y` appear in the second echo command!

Finally adds an overload for `drop` that takes `varargs` of columns and returns a new DF.