### PR TITLE
Fixes for formulas in generics, `seqsToDf` can take scalars

### DIFF
--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -31,6 +31,7 @@ type
       valName*: string
       valKind*: ValueKind
       fnS*: proc(c: DataFrame): Value
+    of fkNone: discard
 
   FormulaMismatchError* = object of CatchableError
 
@@ -75,6 +76,7 @@ proc toUgly*(result: var string, node: FormulaNode) =
     result = $node.colName
   of fkScalar:
     result = $node.valName
+  of fkNone: discard
 
 proc `$`*(node: FormulaNode): string =
   ## Converts `node` to its string representation

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -807,18 +807,6 @@ proc assignType(heuristicType: FormulaTypes, typ: PossibleTypes, arg = 0): Formu
   else:
     result = heuristicType
 
-proc toTypeSeq(t: PossibleTypes, inputs: bool): seq[NimNode] =
-  case t.kind
-  of tkExpression:
-    result = t.types
-  of tkProcedure:
-    for pt in t.procTypes:
-      if inputs:
-        result.add pt.inputTypes
-      elif pt.resType.isSome:
-        result.add pt.resType.get
-  else: discard
-
 proc detNumArgs(n: NimNode): int =
   case n.kind
   of nnkCall, nnkCommand, nnkPrefix:

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -590,9 +590,6 @@ proc maybeAddSpecialTypes(possibleTypes: var PossibleTypes, n: NimNode) =
 
 proc findType(n: NimNode, numArgs: int): PossibleTypes =
   ## This procedure tries to find type information about a given NimNode.
-  ## It must be a symbol (or contain one) of some kind. It should not be used for
-  ## literals, as they have fixed type information.
-  ## NOTE: this may be changed in the future! Currently this is used to
   var possibleTypes = PossibleTypes()
   case n.kind
   of nnkIntLit .. nnkFloat64Lit, nnkStrLit:

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -953,10 +953,12 @@ proc determineTypesImpl(n: NimNode, tab: Table[string, NimNode], heuristicType: 
     ## TODO: need to handle regular `nnkBracketExpr`. Can this appear? If pure we wouldn't be here
   of nnkInfix:
     let lSym = buildName(n[0])
-    let nSym = tab[lSym]
-    doAssert not (n[1].isPureTree and n[2].isPureTree), "Both infix subtrees cannot be pure. We wouldn't have entered"
-    # determine type of infix symbol
-    var infixType = nSym.findType(numArgs = detNumArgs(n))
+    var infixType: PossibleTypes
+    if lSym in tab: # the symbol should really be in `tab`. Let's try to continue otherwise
+      let nSym = tab[lSym]
+      doAssert not (n[1].isPureTree and n[2].isPureTree), "Both infix subtrees cannot be pure. We wouldn't have entered"
+      # determine type of infix symbol
+      infixType = nSym.findType(numArgs = detNumArgs(n))
     # first extract all possible types for the infix arguments
     let (impureIdxs, chTyps) = determineChildTypesAndImpure(n, tab)
     case infixType.kind

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -836,7 +836,7 @@ proc argsValid(pt: ProcType, args: seq[PossibleTypes]): bool =
     # `impure` arguments are `tkNone`. Even might have impure indices for which we could determine
     # type information!
     let arg = args[i]
-    case args[i].kind
+    case arg.kind
     of tkExpression:
       var anyTyp = false
       for t in arg.types:

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -662,7 +662,7 @@ proc findType(n: NimNode, numArgs: int): PossibleTypes =
         let pt = determineTypeFromProc(tImpl, numArgs)
         if pt.isSome:
           possibleTypes.add pt.get
-      of nnkMacroDef:
+      of nnkMacroDef, nnkTemplateDef:
         # skip macro defs, e.g. like Unchained defining `*`, ... macros
         continue
       else:

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -1,4 +1,4 @@
-import macros, tables, sequtils, sets, algorithm, options, strutils
+import macros, tables, sequtils, sets, algorithm, options, strutils, hashes
 import value, column, df_types
 # formulaNameMacro contains a macro and type based on the fallback `FormulaNode`,
 # which is used to generate the names of each `FormulaNode` in lisp representation
@@ -56,6 +56,23 @@ type
     isGeneric: bool
     inputTypes: seq[NimNode] # types of all arguments
     resType: Option[NimNode]
+
+proc hash*(fn: FormulaNode): Hash =
+  result = hash(fn.kind.int)
+  result = result !& hash(fn.name)
+  case fn.kind
+  of fkVariable:
+    result = result !& hash(fn.val)
+  of fkAssign:
+    result = result !& hash(fn.lhs)
+    result = result !& hash(fn.rhs)
+  of fkVector:
+    result = result !& hash(fn.resType)
+    result = result !& hash(fn.fnV)
+  of fkScalar:
+    result = result !& hash(fn.valKind)
+    result = result !& hash(fn.fnS)
+  of fkNone: discard
 
 proc raw*(node: FormulaNode): string =
   ## prints the raw stringification of `node`

--- a/src/datamancer/formulaExp.nim
+++ b/src/datamancer/formulaExp.nim
@@ -15,6 +15,7 @@ type
   ## a data frame. Pure formulas represent raw expressions that evaluate to
   ## a simple `Value`
   FormulaKind* = enum
+    fkNone = "none" ## default value for uninitialized formula / no formula kind at CT yet
     fkVariable = "" ## Nim variable as `Value`, pure
     fkAssign = "<-" ## assignment op, pure
     fkVector = "~" ## map operation, impure

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -555,7 +555,7 @@ proc writeCsv*(df: DataFrame, filename: string, sep = ',', header = "",
     data.add "\n"
   writeFile(filename, data)
 
-proc showBrowser*(df: DataFrame, toRemove = false) =
+proc showBrowser*(df: DataFrame, fname = "df.html", path = getTempDir(), toRemove = false) =
   ## Displays the given DataFrame as a table in the default browser.
   ##
   ## Note: the HTML generation is not written for speed at this time. For very large
@@ -605,7 +605,7 @@ tr:nth-child(even) {
       body.add &"<td>{pretty(x)}</td>"
     body.add "\n</tr>"
   body.add "</tbody>"
-  let fname = getTempDir() / "df.html"
+  let fname = path / fname
   writeFile(fname, tmpl % [header & body])
   openDefaultBrowser(fname)
   if toRemove:

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1205,6 +1205,22 @@ t_in_s,  C1_in_V,  C2_in_V,  type
 
       check dfTr.select("subMeanHwy").unique()["subMeanHwy", float] == expDf.select("subMeanHwy")["subMeanHwy", float]
 
+  test "Construction with scalar":
+    var df = seqsToDf({ "x" : @[1,2,3],
+                        "y" : toSeq(5..7),
+                        "z" : "foo",
+                        "α" : 2.5 })
+    check df.len == 3
+    check df["x", int] == [1,2,3].toTensor
+    check df["y", int] == [5,6,7].toTensor
+    check df["z"].kind == colConstant
+    check df["α"].kind == colConstant
+    check df["z"].cCol == %~ "foo"
+    check df["α"].cCol == %~ 2.5
+    df["β"] = 123
+    check df["β"].kind == colConstant
+    check df["β"].cCol == %~ 123
+
 suite "Formulas":
   test "Formula containing `if`":
     let fn = f{int -> int: if `poopoo` > 5:


### PR DESCRIPTION
Some small quality of life improvements (assign constant values to columns for a constant column automatically) and doing the same in `seqsToDf`. And some fixes about usage of formulas in generics (ref: https://github.com/Vindaar/ggplotnim/issues/116#issuecomment-870462394)

~~Currently I broke something. Need to fix it.~~ Fixed.