### PR TITLE
Perf increase for grouped operations, fixes #12

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,10 @@
+* v0.1.8
+- avoid some object conversions in column operations (ref #11)
+- add ~[]=~ overloads for columns for slice assignments
+- *significantly* improve performance of =mutate/transmute= operations
+  for grouped dataframes (O(150,000) groups in < 0.5 s possible now)
+- fixes #12 by avoiding hashing of columns. Some performance
+  regression in =innerJoin=, =setDiff= (~2x slower in bad cases).    
 * v0.1.7
 - allow assignment of constants in =seqsToDf=
 - allow assignment of scalars to DF as column directly

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -501,11 +501,12 @@ proc `[]=`*(c: var Column, slice: Slice[int], col: Column) =
   if c.compatibleColumns(col) and c.kind != colConstant:
     withNativeDtype(c):
       c[slice] = col.toTensor(dtype)
-  elif c.kind == colConstant:
+  elif c.kind == colConstant and col.kind == colConstant:
     if c.cCol == col.cCol: return # nothing to do
     else:
-      c = c.toObjectColumn()
-      c.oCol[sa .. sb] = col.toTensor(Value)
+      c = c.constantToFull()
+      let c2 = col.constantToFull()
+      c[slice] = c2
   else:
     c = c.toObjectColumn()
     c.oCol[sa .. sb] = col.toTensor(Value)

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -426,6 +426,9 @@ proc `[]=`*[T](c: var Column, idx: int, val: T) =
     c.oCol[idx] = %~ val
   of colConstant:
     if c.cCol == %~ val: discard # do nothing
+    elif c.cCol.kind == VNull:
+      # turn into constant column of `val`
+      c.cCol = %~ val
     else:
       # need to replace constant column by non constant with changed value at
       # specified index

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -449,7 +449,6 @@ proc `[]=`*[T](c: var Column, slice: Slice[int], t: Tensor[T]) =
   let length = slice.b - slice.a + 1
   let sa = slice.a
   let sb = slice.b
-  echo "Assigning slice of length ", length
   if length != t.size:
     raise newException(ValueError, "Given tensor of size " & $t.size & " does not match slice " &
       $slice & " with length: " & $length & ".")

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -464,7 +464,9 @@ proc `[]=`*[T](c: var Column, slice: Slice[int], t: Tensor[T]) =
       c.oCol[sa .. sb] = t.asValue()
   of colFloat:
     when T is float:
-      c.fCol[sa .. sb | 1] = t
+      c.fCol[sa .. sb] = t
+    elif T is int:
+      c.fCol[sa .. sb] = t.asType(float)
     else:
       c = c.toObjectColumn()
       c.oCol[sa .. sb] = t.asValue()

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -641,8 +641,10 @@ proc assignStack(dfs: seq[DataFrame]): DataFrame =
     var col = result[k]
     var idx = 0
     for df in dfs:
+      if df.len == 0: continue
       col[idx .. idx + df.len - 1] = df[k]
       inc idx, df.len
+    result[k] = col
 
 proc hashColumn*(s: var seq[Hash], c: Column, finish: static bool = false) =
   ## performs a partial hash of a DF. I.e. a single column, where

--- a/src/datamancer/value.nim
+++ b/src/datamancer/value.nim
@@ -291,7 +291,11 @@ template withNative*(v: Value,
   of VBool:
     let `valName` {.inject.} =  v.bval
     body
-  of VObject, VNull:
+  of VNull:
+    # a null value is just a null value
+    let `valName` {.inject.} =  v
+    body
+  of VObject:
     doAssert false, "not implemented / makes no sense for current usage"
 
 template withNativeConversion*(kind: ValueKind,


### PR DESCRIPTION
Full changelog:

```
* v0.1.8
- avoid some object conversions in column operations (ref #11)
- add ~[]=~ overloads for columns for slice assignments
- *significantly* improve performance of =mutate/transmute= operations
  for grouped dataframes (O(150,000) groups in < 0.5 s possible now)
- fixes #12 by avoiding hashing of columns. Some performance
  regression in =innerJoin=, =setDiff= (~2x slower in bad cases).
```