### PR TITLE
Fix formula column name generation + performance improvement

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -3,7 +3,11 @@
   to dplyr =pivot_wider=). The current implementation is rather basic
   and performance may be suboptimal for very large data frames.
 - add =null= helper to create a =VNull Value=
-- significantly improve the docs of the =dataframe.nim= module.  
+- significantly improve the docs of the =dataframe.nim= module.
+- fixes an issue where unique column reference names were combined
+  into the same column due to a bad name generation algorithm
+- significantly improves performance in applications in which
+  allocation of memory is a bottleneck (tensors were zero initialized).
 * v0.1.8
 - avoid some object conversions in column operations (ref #11)
 - add ~[]=~ overloads for columns for slice assignments

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -390,21 +390,13 @@ proc determineHeuristicTypes(body: NimNode,
       "Consider giving type hints via: `f{T -> U: <theFormula>}`")
   result = typ
 
-proc removeAll(s: string, chars: set[char]): string =
-  result = newStringOfCap(s.len)
-  for c in s:
-    if c notin chars:
-      result.add c
-  if result.len == 0:
-    result = "col"
-
 proc genColSym(name, s: string): NimNode =
   ## custom symbol generation from `name` (may contain characters that are
   ## invalid Nim symbols) and `s`
-  let toRemove = AllChars - IdentStartChars
-  var res = removeAll(name, toRemove)
-  res &= s
-  result = ident(res)
+  var name = name
+  if name.len == 0 or name[0] notin IdentStartChars:
+    name = "col" & name
+  result = ident(name & s)
 
 proc addColRef(n: NimNode, typeHint: FormulaTypes, asgnKind: AssignKind): seq[Assign] =
   let (dtype, resType) = (typeHint.inputType, typeHint.resType)

--- a/src/datamancer/formulaExp.nim
+++ b/src/datamancer/formulaExp.nim
@@ -230,7 +230,7 @@ proc convertDtype(d: NimNode): NimNode =
       ident(ResIdent),
       newEmptyNode(),
       nnkCall.newTree(
-        nnkBracketExpr.newTree(ident"newTensor",
+        nnkBracketExpr.newTree(ident"newTensorUninit",
                                d),
         nnkDotExpr.newTree(ident(DfIdent),
                            ident"len"))

--- a/tests/testsFormula.nim
+++ b/tests/testsFormula.nim
@@ -257,3 +257,10 @@ suite "Formulas":
       let fn = f{"mean+ord" << mean(`x`) + col(`y`, string).max[0].ord.float }
       check fn.reduce(df).kind == VFloat
       check fn.reduce(df).toFloat == 104.0
+
+  test "Formula variable name generation":
+    # this was broken up to `v0.1.8`, as all variables were turned into `colT`
+    # (we just *removed* the part that made each column unique)
+    let df = seqsToDf({"0" : [1,1,1], "1" : [2,2,2], "2" : [3,3,3]})
+    let fn = f{idx("0") + idx("1") + idx("2")}
+    check fn.evaluate(df).toTensor(int) == toTensor [6,6,6]


### PR DESCRIPTION
Fixes an issue where unique columns were treated as the same column due to bad identifier generation.

Also significantly improves performances in applications, in which memory allocations are important. We accidentally zero initialized the tensors we write to (which is unnecessary, as we assign values to the full tensor *every time* in the following loop).

### From the commit message

This is a bad left over from writing the experimental macro (hehe
`formulaExp == formula experimental`...). Fitting that I overlooked
this.

As we are overwriting the full tensor in the loop immediately, there
is absolutely no reason to pre initialize our tensor. That's just a
wasted run over the tensor data.

In a mini benchmark of very large columns, this leads to a > 2x
performance loss as the allocation & initialization is not
multithreaded.

(This depends on an update in arraymancer, as we falsely used
`allocShared0` there, so `newTensorUninit` didn't work as expected).

Note: of course the following is *not* super scientific.

Compiled on devel (30-06-21) with `-d:danger -d:openmp` flags.

```nim
import datamancer
import random
import std/monotimes

proc genDf(): DataFrame =
  result = newDataFrame()
  for i in 0 ..< 4:
    var t = newTensorUninit[float](750_000_000)
    for j in 0 ..< t.size:
      t[j] = rand(1.0)
    result[$i] = t

proc main() =
  echo "Generating DF"
  let df = genDf()
  echo "Done, starting compute"
  let t0 = getMonoTime()
  for i in 0 ..< 50:
    let df2 = df.mutate(f{"foo" ~ idx("0") * idx("1") + idx("2") * idx("3")})
  echo "took ", getMonoTime() - t0

when isMainModule:
  main()
```
Outputs:

took (seconds: 51, nanosecond: 801431879)

Eats about ~30 GB (40 GB peak) of RAM. Filling the DF takes much longer than the
mutation call. After fix this is ~1.5x faster than similar pandas code:

```python
import pandas as pd
import numpy as np
import time

def genDf():
  result = pd.DataFrame()
  for i in range(4):
    ar = np.random.random_sample((750_000_000, ))
    result[str(i)] = ar
  print(result)
  return result

def main():
  print("Generating DF")
  df = genDf()
  print("Done, starting compute")
  t0 = time.monotonic()
  for i in range(50):
      print("start")
      res = df["0"] * df["1"] + df["2"] * df["3"]
      print("done")
  print("took ", time.monotonic() - t0)
main()
```
Pandas *also* eats >40 GB of RAM, peaking at over 50 GB.

Outputs:
took  95.36373260799883
