### PR TITLE
Remove CT output

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -7,7 +7,11 @@
 - fixes an issue where unique column reference names were combined
   into the same column due to a bad name generation algorithm
 - significantly improves performance in applications in which
-  allocation of memory is a bottleneck (tensors were zero initialized).
+  allocation of memory is a bottleneck (tensors were zero
+  initialized).
+- disable formula output at CT by default. Compile with
+  =-d:echoFormulas= to see the output.
+- remove CT warnings for unrelated stuff (node kinds)  
 * v0.1.8
 - avoid some object conversions in column operations (ref #11)
 - add ~[]=~ overloads for columns for slice assignments

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -194,7 +194,8 @@ proc compileVectorFormula(fct: FormulaCT): NimNode =
                 colName: `colName`, kind: fkVector,
                 resType: toColKind(type(`dtype`)),
                 fnV: `fnClosure`)
-  echo result.repr
+  when defined(echoFormulas):
+    echo result.repr
 
 proc compileScalarFormula(fct: FormulaCT): NimNode =
   let fnClosure = generateClosure(fct)
@@ -206,7 +207,8 @@ proc compileScalarFormula(fct: FormulaCT): NimNode =
                 valName: `valName`, kind: fkScalar,
                 valKind: toValKind(`dtype`),
                 fnS: `fnClosure`)
-  echo result.repr
+  when defined(echoFormulas):
+    echo result.repr
 
 proc checkDtype(body: NimNode,
                 floatSet: HashSet[string],

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -615,8 +615,9 @@ proc findType(n: NimNode, numArgs: int): PossibleTypes =
         if typ.kind != nnkEmpty:
           return PossibleTypes(isGeneric: false, kind: tkExpression,
                                types: @[typ], asgnKind: some(byIndex))
-        warning("How did we stumble over " & $(n.treeRepr) & " with type " &
-          $(tImpl.treeRepr))
+        when false:
+          warning("How did we stumble over " & $(n.treeRepr) & " with type " &
+            $(tImpl.treeRepr))
         #return
   of nnkCheckedFieldExpr:
     let impl = n.getTypeImpl
@@ -809,7 +810,6 @@ proc detNumArgs(n: NimNode): int =
     result = 1
   else:
     result = 1
-    warning("What kind? " & $n.kind & " in node " & n.repr)
 
 proc argsValid(pt: ProcType, args: seq[PossibleTypes]): bool =
   ## This procedure removes all `ProcTypes` from the input `pt` that do not match the given


### PR DESCRIPTION
This disables the default output of generated formulas. 

To see the output of the generated formulas, compile with `-d:echoFormulas`.