### PR TITLE
Fix CSV parsing for missing values in first row if non float column

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -3,7 +3,11 @@
 - fix CSV parsing wrt. empty fields (treated as NaN) and explicit NaN
   & Inf values
 - fix CSV parsing of files with extraneous newlines
-- add more parsing tests  
+- fix CSV parsing with missing values at the end of a line (becomes
+  =NaN=)
+- fix CSV parsing of empty fields if missing in first row and element
+  is *not* float
+- add more parsing tests
 * v0.1.9
 - add basic implementation of =spread= (inverse of =gather=; similar
   to dplyr =pivot_wider=). The current implementation is rather basic

--- a/datamancer.nimble
+++ b/datamancer.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.8"
+version       = "0.1.10"
 author        = "Vindaar"
 description   = "A dataframe library with a dplyr like API"
 license       = "MIT"

--- a/docs/docs.nim
+++ b/docs/docs.nim
@@ -24,7 +24,7 @@ proc getNimRootDir(): string =
   import "$nim/testament/lib/stdtest/specialpaths.nim"
   nimRootDir
   ]#
-  fmt"{currentSourcePath}".parentDir.parentDir.parentDir
+  getCurrentCompilerExe().parentDir.parentDir
 
 const
   DirSep = when defined(windows): '\\' else: '/'

--- a/docs/docs.nim
+++ b/docs/docs.nim
@@ -94,7 +94,7 @@ proc buildDocs*(path: string, docPath: string,
   ## https://github.com/nim-lang/Nim/pull/11814 is required.
   ##
   ##
-  const gitUrl = "https://github.com/Vindaar/datamancer"
+  const gitUrl = "https://github.com/SciNim/datamancer"
   ## WARNING: this means `gen_docs` *only* works if you use `nimble develop` on
   ## the repository. Nimble cannot deal with ****. This is frustrating. Thanks.
   let baseDir = execAction("nimble path datamancer").parentDir & $DirSep


### PR DESCRIPTION
The previous PR #20 indirectly started with the assumption that every column that has missing values in the first row is a float column. That is of course not valid. 

Our type guessing game is now extended to the first row that contains values for each column. So missing values in the first row are not taken into account for type determination anymore.