### PR TITLE
Convenience templates for object columns

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,10 @@
+* v0.1.11
+- add convenience comparison operators for =Value= elements of a
+  column with regular types *within a =f{}= formula* (they are emitted
+  as templates into the closure scope to avoid having them available
+  in all scopes).
+  Use the =convenienceValueComparisons= template to emit them to a
+  local scope if desired outside formula scopes.
 * v0.1.10
 - make sure to only import and export =arraymancer/tensor= submodule
 - fix CSV parsing wrt. empty fields (treated as NaN) and explicit NaN

--- a/src/datamancer/formulaExp.nim
+++ b/src/datamancer/formulaExp.nim
@@ -504,6 +504,7 @@ proc parseFormulaCT(stmts: NimNode): FormulaCT =
 
 proc generateClosure*(fct: FormulaCT): NimNode =
   var procBody = newStmtList()
+  procBody.add getAst(convenienceValueComparisons()) # add convenience comparison ops Value ⇔ T
   procBody.add convertPreface(fct.preface)
   if fct.funcKind == fkVector:
     procBody.add convertDtype(fct.resType)

--- a/src/datamancer/value.nim
+++ b/src/datamancer/value.nim
@@ -383,6 +383,26 @@ proc `==`*(v, w: Value): bool =
     of VNull:
       result = true
 
+template convenienceValueComparisons*(): untyped =
+  ## These are a few comparison procedures that are defined for convenience within the context
+  ## of a `f{}` formula to allow writing
+  ## `foo` == "bar"
+  ## even if `foo` is actually a `Value` based column.
+  ##
+  ## This is handled by simply inserting these templates into the closure body.
+  ##
+  ## Feel free to call the template in a local (or global) scope to make them available
+  ## in other scopes. Note that the templates are *not* exported!
+  {.push used.} # NOTE: hint[XDeclaredButNotUsed]: off has no effect.
+                # `used` successfully quiets the compiler about unused templates
+  template `==`[T: char | string | SomeNumber | bool](v: Value, x: T): bool = v == %~ x
+  template `==`[T: char | string | SomeNumber | bool](x: T, v: Value): bool = v == %~ x
+  template `<`[T: char | string | SomeNumber | bool](v: Value, x: T): bool  = v <  %~ x
+  template `<`[T: char | string | SomeNumber | bool](x: T, v: Value): bool  = v <  %~ x
+  template `<=`[T: char | string | SomeNumber | bool](v: Value, x: T): bool = v <= %~ x
+  template `<=`[T: char | string | SomeNumber | bool](x: T, v: Value): bool = v <= %~ x
+  {.pop.}
+
 proc `<`*(v, w: Value): bool =
   ## checks whether the `v` is smaller than `w`
   ## Note: this is only defined for a subset of the possible types!

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1497,3 +1497,60 @@ suite "Formulas":
     check dfSlice["Energy", int] == [24, 0, 1].toTensor
     check dfSlice["Counts", int] == [24, 0, 1].toTensor
     check dfSlice["Type", string] == ["background", "background", "background"].toTensor
+suite "Formulas with object columns using convenience operators":
+  test "int comparisons":
+    let df = seqsToDf({"x" : [%~ 1, %~ 2, %~ 3]})
+    check df.filter(f{`x` == 1})["x", int] == [1].toTensor
+    check df.filter(f{`x` != 1})["x", int] == [2,3].toTensor
+    check df.filter(f{`x` > 1})["x", int] == [2,3].toTensor
+    check df.filter(f{`x` >= 1})["x", int] == [1,2,3].toTensor
+    check df.filter(f{`x` < 2})["x", int] == [1].toTensor
+
+    check df.filter(f{1 == `x`})["x", int] == [1].toTensor
+    check df.filter(f{1 != `x`})["x", int] == [2,3].toTensor
+    check df.filter(f{1 < `x`})["x", int] == [2,3].toTensor
+    check df.filter(f{1 <= `x`})["x", int] == [1,2,3].toTensor
+    check df.filter(f{2 > `x`})["x", int] == [1].toTensor
+
+  test "float comparisons":
+    let df = seqsToDf({"x" : [%~ 1.0, %~ 2.0, %~ 3.0]})
+    check df.filter(f{`x` == 1.0})["x", float] == [1.0].toTensor
+    check df.filter(f{`x` != 1.0})["x", float] == [2.0,3.0].toTensor
+    check df.filter(f{`x` > 1.0})["x", float] == [2.0,3.0].toTensor
+    check df.filter(f{`x` >= 1.0})["x", float] == [1.0,2.0,3.0].toTensor
+    check df.filter(f{`x` < 2.0})["x", float] == [1.0].toTensor
+
+    check df.filter(f{1.0 == `x`})["x", float] == [1.0].toTensor
+    check df.filter(f{1.0 != `x`})["x", float] == [2.0,3.0].toTensor
+    check df.filter(f{1.0 < `x`})["x", float] == [2.0,3.0].toTensor
+    check df.filter(f{1.0 <= `x`})["x", float] == [1.0,2.0,3.0].toTensor
+    check df.filter(f{2.0 > `x`})["x", float] == [1.0].toTensor
+
+  test "float comparisons with int Value":
+    let df = seqsToDf({"x" : [%~ 1, %~ 2, %~ 3]})
+    check df.filter(f{`x` == 1.0})["x", int] == [1].toTensor
+    check df.filter(f{`x` != 1.0})["x", int] == [2,3].toTensor
+    check df.filter(f{`x` > 1.0})["x", int] == [2,3].toTensor
+    check df.filter(f{`x` >= 1.0})["x", int] == [1,2,3].toTensor
+    check df.filter(f{`x` < 2.0})["x", int] == [1].toTensor
+
+    check df.filter(f{1.0 == `x`})["x", int] == [1].toTensor
+    check df.filter(f{1.0 != `x`})["x", int] == [2,3].toTensor
+    check df.filter(f{1.0 < `x`})["x", int] == [2,3].toTensor
+    check df.filter(f{1.0 <= `x`})["x", int] == [1,2,3].toTensor
+    check df.filter(f{2.0 > `x`})["x", int] == [1].toTensor
+
+  test "bool comparisons":
+    let df = seqsToDf({"x" : [true, false, true]})
+    check df.filter(f{`x` == true})["x", bool] == [true, true].toTensor
+    check df.filter(f{`x` == false})["x", bool] == [false].toTensor
+
+    check df.filter(f{`x` != true})["x", bool] == [false].toTensor
+    check df.filter(f{`x` != false})["x", bool] == [true, true].toTensor
+
+  test "string comparisons":
+    let df = seqsToDf({"x" : ["foo", "bar", "baz"]})
+    check df.filter(f{`x` == "foo"})["x", string] == ["foo"].toTensor
+    check df.filter(f{`x` != "foo"})["x", string] == ["bar", "baz"].toTensor
+    check df.filter(f{`x` in ["foo", "bar"]})["x", string] == ["foo", "bar"].toTensor
+    check df.filter(f{`x` notin ["foo", "bar"]})["x", string] == ["baz"].toTensor

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1497,6 +1497,24 @@ suite "Formulas":
     check dfSlice["Energy", int] == [24, 0, 1].toTensor
     check dfSlice["Counts", int] == [24, 0, 1].toTensor
     check dfSlice["Type", string] == ["background", "background", "background"].toTensor
+
+  test "Single function call in formula":
+    proc inRegion(x, y: float, r: string): bool =
+      result = x > 1
+    let df = seqsToDf({"x" : [1,2,3], "y" : [4,5,6]})
+    let rad = "foo"
+    let res = df.filter(f{inRegion(`x`, `y`, rad)})
+    check res["x", int] == [2,3].toTensor
+
+  test "Formula referring to bool column":
+    let df = seqsToDf({"x" : [1,2,3], "y" : [true, false, true]})
+    block IsTrue:
+      let res = df.filter(f{bool: `y`})
+      check res["x", int] == [1,3].toTensor
+    block IsFalse:
+      let res = df.filter(f{bool: not `y`})
+      check res["x", int] == [2].toTensor
+
 suite "Formulas with object columns using convenience operators":
   test "int comparisons":
     let df = seqsToDf({"x" : [%~ 1, %~ 2, %~ 3]})


### PR DESCRIPTION
This adds a bunch of convenience templates for dealing with object columns to better deal with comparisons within a formula `f{}` scope.

Within such a scope  we now emit a few templates that allow for lenient operations between `Values` (from the object column) and regular types. This means the user does not have to type `%~` all over formulas, which isn't very intuitive. 

In addition adds two more test cases for things I recently stumbled over and wasn't sure if they work correctly (they do).