### PR TITLE
tests add -d:nimPreviewFloatRoundtrip support

### DIFF
--- a/tests/testParse.nim
+++ b/tests/testParse.nim
@@ -136,7 +136,10 @@ suite "`parseNumber` tests":
 
     # start after first separator
     for i in 123456789 .. 123456789 + 50:
-      checkFloat($toFloat(i) & "," & $toFloat(i), toFloat(i), start = 18)
+      when defined(nimPreviewFloatRoundtrip):
+        checkFloat($toFloat(i) & "," & $toFloat(i), toFloat(i), start = 19)
+      else:
+        checkFloat($toFloat(i) & "," & $toFloat(i), toFloat(i), start = 18)
 
     # some exp notation
     checkFloat("1e5", 1e5, start = 0)


### PR DESCRIPTION
nimpreviewFloatRoundtrip will soon become a default option. And it seems to be a precision problem so I changed `start` to 19 to pass tests.

It is blocking https://github.com/nim-lang/Nim/pull/19388