### PR TITLE
`v0.2.0` with formula & constant column improvements 

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,78 @@
+* v0.2.0
+- *MAJOR, BREAKING*: Add experimental support for "non-generic generic
+  =Columns=". Essentially, from many procedures it is now possible to
+  assign data types that are normally not supported to be stored
+  inside of a =DataFrame=. With a lot of macro magic however, we
+  generate a new =Column= type that is able to store such a data
+  type. Then we return a new =DataFrame= for the user that uses the
+  new =Column= type. For that reason =DataFrame= is now a generic type
+  (generic over the =Column= type) and the notion of the =Column= has
+  become a =ColumnLike= concept. This was the easiest way to add
+  support for things like:
+  - =DateTime=
+  - arbitrary =unchained= units in a DF
+  - =Measurement= objects =Measuremancer=
+  - ... whatever else you can think of. As long as it fits into a
+    =Tensor[T]=, you can now place it into a DF!
+  See XXX for a short introduction on the feature.
+- constant =DataFrame= columns have seen improvements. Before most
+  operations on them would convert them to a non-constant column,
+  often forced to convert to an object column. Now, most operations
+  (that make sense) are supported on constants themselves and if a
+  non-constant conversion is required, it aims to use the type
+  corresponding to the underlying =Value= kind of the constant. That
+  way conversions of constants to full columns should now lead to
+  native (float, int, string, bool) tensors (unless an operation with
+  another native, incompatible type is performed)
+- some bugs were fixed that could cause reference semantics of
+  dataframes to shine through when using =filter=
+- *BREAKING*: the =toValueKind= procedure now takes a =Column= instead
+  of a =ColumnKind=. This is to be able to handle the constant to full
+  conversion properly. Note: A deprecated variant of the former
+  version is still around!
+- add =filterToIdx=, which takes a DF and a sequence / tensor of
+  integers. The procedure will keep only those rows of the DF whose
+  indices are part of the seq/Tensor
+- slight performance improvements for the parsing of CSV files (larger
+  for string heavy files) by avoiding an unnecessary =newString= call
+  (yeah, =setLen= resizes for you if needed...)
+- allow more valid Nim code inside of =f{}= formulas, e.g. if
+  expressions and block statements
+- fix type determinations in =f{}= formulas, if a procedure with
+  default parameters, but no explicit type information is given.  
+- certain expressions in =f{}= formulas (for example
+  =isNaN(idx("foo"))=) could produce unintended CT errors and work now
+  (sorry, had to add a =when compiles= check :( ).
+- *SEMI-BREAKING*: add preliminary support for reducing formulas that require a =for=
+  loop. This (currently) allows for ~res += <formula>~ like statements
+  inside of a loop instead of just ~res = <formula>~ where in the
+  latter the formula must produce a scalar by itself (i.e. does not
+  allow *element wise* access to columns). Now a formula that accesses
+  a single element via =idx(...)= will produce a loop with an
+  accumulation.
+- experimental support for "full formulas" as I call them that allow
+  to have more control over variables in the scope of the formula:
+  #+begin_src nim
+  formula:
+    preface:
+      foo in df["Foo", float]
+      bar in baz(df["Bar", int])
+    loop:
+      bar^2.float + foo  
+  #+end_src
+  allows for custom variable names inside of the context (and more
+  importantly) to perform a full column operation (e.g. =baz=) on a
+  column *before* the loop and use the elements of that operation
+  inside of the loop. Note that this is _not_ for *reducing* operations
+  on columns (i.e. =mean(df["Bar", float])=)! It is still planned to
+  lift reducing operations out of the loop body, but that is still
+  pending.
+- add (experimental) =lag=, =lead= procedures that take a
+  =Tensor/Column= and return a new =Tensor/Column= that is shiftet
+  forward / backward N elements (the left overs are zeroed, the
+  shifted ones are dropped).
+- the =showBrowser= helper to view a =DataFrame= in the browser now
+  adds an additional "index" column
 * v0.1.11
 - add convenience comparison operators for =Value= elements of a
   column with regular types *within a =f{}= formula* (they are emitted

--- a/changelog.org
+++ b/changelog.org
@@ -73,6 +73,8 @@
   shifted ones are dropped).
 - the =showBrowser= helper to view a =DataFrame= in the browser now
   adds an additional "index" column
+- improve performance of =groups= iterator (particularly in cases
+  where the DF is already sorted / the sorting is cheap)  
 * v0.1.11
 - add convenience comparison operators for =Value= elements of a
   column with regular types *within a =f{}= formula* (they are emitted

--- a/changelog.org
+++ b/changelog.org
@@ -1,4 +1,4 @@
-* v0.2.0 (To be finalized...)
+* v0.3.0 (To be finalized...)
 - *MAJOR, BREAKING*: Add experimental support for "non-generic generic
   =Columns=". Essentially, from many procedures it is now possible to
   assign data types that are normally not supported to be stored
@@ -15,7 +15,7 @@
   - ... whatever else you can think of. As long as it fits into a
     =Tensor[T]=, you can now place it into a DF!
   See XXX for a short introduction on the feature.
-* v0.1.12
+* v0.2.0
 - constant =DataFrame= columns have seen improvements. Before most
   operations on them would convert them to a non-constant column,
   often forced to convert to an object column. Now, most operations

--- a/changelog.org
+++ b/changelog.org
@@ -1,4 +1,4 @@
-* v0.2.0
+* v0.2.0 (To be finalized...)
 - *MAJOR, BREAKING*: Add experimental support for "non-generic generic
   =Columns=". Essentially, from many procedures it is now possible to
   assign data types that are normally not supported to be stored
@@ -15,6 +15,7 @@
   - ... whatever else you can think of. As long as it fits into a
     =Tensor[T]=, you can now place it into a DF!
   See XXX for a short introduction on the feature.
+* v0.1.12
 - constant =DataFrame= columns have seen improvements. Before most
   operations on them would convert them to a non-constant column,
   often forced to convert to an object column. Now, most operations
@@ -43,13 +44,6 @@
 - certain expressions in =f{}= formulas (for example
   =isNaN(idx("foo"))=) could produce unintended CT errors and work now
   (sorry, had to add a =when compiles= check :( ).
-- *SEMI-BREAKING*: add preliminary support for reducing formulas that require a =for=
-  loop. This (currently) allows for ~res += <formula>~ like statements
-  inside of a loop instead of just ~res = <formula>~ where in the
-  latter the formula must produce a scalar by itself (i.e. does not
-  allow *element wise* access to columns). Now a formula that accesses
-  a single element via =idx(...)= will produce a loop with an
-  accumulation.
 - experimental support for "full formulas" as I call them that allow
   to have more control over variables in the scope of the formula:
   #+begin_src nim
@@ -67,14 +61,32 @@
   on columns (i.e. =mean(df["Bar", float])=)! It is still planned to
   lift reducing operations out of the loop body, but that is still
   pending.
-- add (experimental) =lag=, =lead= procedures that take a
-  =Tensor/Column= and return a new =Tensor/Column= that is shiftet
-  forward / backward N elements (the left overs are zeroed, the
-  shifted ones are dropped).
+- *SEMI-BREAKING*: add preliminary support for reducing formulas that require a =for=
+  loop. This (currently) allows for ~res += <formula>~ like statements
+  inside of a loop instead of just ~res = <formula>~ where in the
+  latter the formula must produce a scalar by itself (i.e. does not
+  allow *element wise* access to columns). Now a formula that accesses
+  a single element via =idx(...)= will produce a loop with an
+  accumulation.
+  Note: to make use of this feature you *must* use the full formula
+  syntax, as otherwise the default value of =res= is unclear.
+  #+begin_src nim
+  formula:
+    preface:
+      var res = 1.0
+      Bidx in df["B", float]
+    loop:
+      res *= Bidx * 1.5
+  #+end_src
+- add =lag=, =lead= procedures that take a =Tensor/Column= and return
+  a new =Tensor/Column= that is shiftet forward / backward N elements
+  (the left overs are zeroed by default, but adjustable using =fill= argument)
 - the =showBrowser= helper to view a =DataFrame= in the browser now
   adds an additional "index" column
 - improve performance of =groups= iterator (particularly in cases
-  where the DF is already sorted / the sorting is cheap)  
+  where the DF is already sorted / the sorting is cheap)
+- fix type deduction issues in formulas using dot expressions for
+  certain cases  
 * v0.1.11
 - add convenience comparison operators for =Value= elements of a
   column with regular types *within a =f{}= formula* (they are emitted

--- a/datamancer.nimble
+++ b/datamancer.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.12"
+version       = "0.2.0"
 author        = "Vindaar"
 description   = "A dataframe library with a dplyr like API"
 license       = "MIT"

--- a/datamancer.nimble
+++ b/datamancer.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.11"
+version       = "0.1.12"
 author        = "Vindaar"
 description   = "A dataframe library with a dplyr like API"
 license       = "MIT"

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -782,36 +782,38 @@ template map_inline*(c: Column, body: untyped): Column =
         "` for dtype of column: " & $(c.kind.toNimType))
     res
 
-proc lag*[T](t: Tensor[T], n = 1): Tensor[T] {.noInit.} =
+proc lag*[T](t: Tensor[T], n = 1, fill: T = default(T)): Tensor[T] {.noInit.} =
   ## Lags the input tensor by `n`, i.e. returns a shifted tensor
   ## such that it *lags* behind `t`:
+  ##
   ## `lag([1, 2, 3], 1) ⇒ [null, 1, 2]`
-  ## NOTE: Currently `null` is just a `default(T)` value! Do not use the values
-  ## left behind for any computation unless you are fine with picking up
-  ## zero values!
+  ##
+  ## NOTE: The value of `null` is filled by `default(T)` value by default!
+  ## Use the `fill` argument to change the value to be set.
   result = newTensorUninit[T](t.size)
   #result[0 ..< n] = leave unspecified for now
   let hi = t.size.int - n
   result[n ..< t.size.int] = t[0 ..< hi]
-  result[0 ..< n] = default(T)
+  result[0 ..< n] = fill
 
 proc lag*(c: Column, n = 1): Column =
   ## Overload of the above for columns
   withNativeDtype(c):
     result = toColumn lag(c.toTensor(dtype), n)
 
-proc lead*[T](t: Tensor[T], n = 1): Tensor[T] {.noInit.} =
+proc lead*[T](t: Tensor[T], n = 1, fill: T = default(T)): Tensor[T] {.noInit.} =
   ## Leads the input tensor by `n`, i.e. returns a shifted tensor
   ## such that it *leads* ahead of `t`:
+  ##
   ## `lead([1, 2, 3], 1) ⇒ [2, 3, null]`
-  ## NOTE: Currently `null` is just a `default(T)` value! Do not use the values
-  ## left behind for any computation unless you are fine with picking up
-  ## zero values!
+  ##
+  ## NOTE: The value of `null` is filled by `default(T)` value by default!
+  ## Use the `fill` argument to change the value to be set.
   result = newTensorUninit[T](t.size)
   #result[0 ..< n] = leave unspecified for now
   let hi = t.size.int - n
-  result[0 ..< n] = t[n ..< hi]
-  result[n ..< t.size.int] = default(T)
+  result[0 ..< hi] = t[n ..< t.size.int]
+  result[hi ..< t.size.int] = fill
 
 proc lead*(c: Column, n = 1): Column =
   ## Overload of the above for columns

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -633,12 +633,12 @@ proc add*(c1, c2: Column): Column =
     case c1.kind
     of colInt:
       # c1 is int, c2 is float
-      assert c2.kind == colFloat
-      result = toColumn concat(c1.iCol.asType(float), c2.fCol, axis = 0)
+      let c2T = c2.constantToFull().toTensor(float)
+      result = toColumn concat(c1.iCol.asType(float), c2T, axis = 0)
     of colFloat:
       # c1 is float, c2 is int
-      assert c2.kind == colInt
-      result = toColumn concat(c1.fCol, c2.iCol.asType(float), axis = 0)
+      let c2T = c2.constantToFull().toTensor(float)
+      result = toColumn concat(c1.fCol, c2T, axis = 0)
     else:
       # one of the two is constant and same type as the other
       # `constantToFull` is a no-op for the non-constant column

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1175,7 +1175,7 @@ proc filter*(df: DataFrame, conds: varargs[FormulaNode]): DataFrame =
     let dfRes = df.filter(f{ `x` < 3 or `y` == "e" }) ## arbitrary boolean expressions supported
     doAssert dfRes["x", int] == [1, 2, 5].toTensor
     doAssert dfRes["y", string] == ["a", "b", "e"].toTensor
-
+  let df = df.shallowCopy # make a shallow copy, as otherwise we might modify the input
   case df.kind
   of dfGrouped:
     var dfs = newSeq[DataFrame]()

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -1160,9 +1160,9 @@ macro compileFormulaImpl*(rawName: static string,
         "kind:\n\t`" & $funcKind & "` (mapping)\nand automatically determined formula kind:\n\t" &
         "<< (reducing)\nPlease adjust the given kind to `<<`.")
     elif not allScalar and funcKind == fkScalar:
-      error("Formula " & $fct.rawName & " has a mismatch between given formula " &
-        "kind:\n\t`" & $funcKind & "` (reducing)\nand automatically determined formula kind:\n\t" &
-        "`~` (mapping)\nPlease adjust the given kind to `~`.")
+      ## user seems to be accessing a tensor in context of a scalar body. Probably wants
+      ## to accumulate with some condition. Generate a for loop with explicit accumulation
+      fct.generateLoop = true
     # use the user given formula kind
     fct.funcKind = funcKind
   else:

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -822,8 +822,8 @@ proc assignType(heuristicType: FormulaTypes, typ: PossibleTypes, arg = 0): Formu
       # take the type with the highest priority as the input type
       let typs = typ.types.sortTypes()
       if typs.len > 0:
-        result = FormulaTypes(inputType: ident(typs[^1]),
-                              resType: heuristicType.resType)
+        result = FormulaTypes(inputType: heuristicType.inputType,
+                              resType: ident(typs[^1]))
       else:
         result = heuristicType
     else:

--- a/src/datamancer/formulaExp.nim
+++ b/src/datamancer/formulaExp.nim
@@ -25,9 +25,7 @@ type
   Assign* = object
     asgnKind*: AssignKind
     node*: NimNode ## the exact node that will be replaced by this `Assign` instance
-    ## TODO: rename / change `ReplaceByKind` as it's currently a bit unclear, in particular after
-    ## `get` and `delete` was added!
-    rbKind*: ReplaceByKind ## stores how this should be inserted
+                   ## In case of `byCustom`, just the user input that will be inserted again
     element*: NimNode # e.g. `t`
     tensor*: NimNode # either `t` or `t_T` if `elmenent` used
     col*: NimNode # name of the column
@@ -272,7 +270,6 @@ proc `$`*(p: Preface): string =
     result.add &"node: {ch.node.repr}, "
     result.add &"tensor: {ch.tensor.strVal}, "
     result.add &"col: {buildName(ch.col)}, "
-    result.add &"rbKind: {ch.rbKind}, "
     result.add &"colType: {buildName(ch.colType)}, "
     result.add &"resType: {buildName(ch.resType)})"
     if i < p.args.high:

--- a/src/datamancer/formulaNameMacro.nim
+++ b/src/datamancer/formulaNameMacro.nim
@@ -74,6 +74,14 @@ proc build(n: NimNode): string =
     ## TODO: check if this is reasonable. It seems that this node contains
     ## the original node as [0] and then the "environment" as [1]??
     result = build(n[0])
+  of nnkBlockStmt:
+    result = "(block"
+    for ch in n:
+      result.add &" {build(ch)}"
+    result.add ")"
+  of nnkStmtListExpr:
+    # just use child node
+    result = build(n[0])
   else:
     result = n.repr
     warning("Node kind " & $n.kind & " not implemented " &

--- a/src/datamancer/formulaNameMacro.nim
+++ b/src/datamancer/formulaNameMacro.nim
@@ -54,9 +54,9 @@ proc build(n: NimNode): string =
     for arg in n:
       result.add &" {build(arg)}"
     result.add ")"
-  of nnkElifExpr:
+  of nnkElifExpr, nnkElifBranch:
     result = buildArgs(n, head = "(elif")
-  of nnkElseExpr:
+  of nnkElseExpr, nnkElse:
     result = buildArgs(n, head = "(else")
   of nnkStmtList:
     for ch in n:
@@ -82,6 +82,8 @@ proc build(n: NimNode): string =
   of nnkStmtListExpr:
     # just use child node
     result = build(n[0])
+  of nnkEmpty:
+    result = ""
   else:
     result = n.repr
     warning("Node kind " & $n.kind & " not implemented " &

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -4,11 +4,6 @@ import memfiles, streams, strutils, tables, parsecsv, sequtils
 # for `showBrowser`
 import browsers, strformat, os
 
-# no-op for backward compatibility with `toDf(readCsv(...))`
-proc toDf*(df: DataFrame): DataFrame {.deprecated: "`toDf` is not required anymore, because `readCsv` " &
-  "already returns an actual `DataFrame` nowadays. Feel free to remove the `toDf` call."} =
-  df
-
 proc checkHeader(s: Stream, fname, header: string, colNames: seq[string]): bool =
   ## checks whether the given file contains the header `header`
   result = true

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -672,15 +672,20 @@ tr:nth-child(even) {
     header: string
     body: string
   header = "<thead>\n<tr>"
+  header.add &"<th> Index </th>"
   for k in df.getKeys:
     header.add &"<th> {k} <br><br> {df[k].kind.toNimType} </th>"
   header.add "</tr>\n</thead>"
   body = "<tbody>"
+  var idx = 0
   for row in df:
     body.add "<tr>\n"
+    # first add column for index
+    body.add &"<td>{idx}</td>"
     for x in row:
       body.add &"<td>{pretty(x)}</td>"
     body.add "\n</tr>"
+    inc idx
   body.add "</tbody>"
   let fname = path / fname
   writeFile(fname, tmpl % [header & body])

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -86,10 +86,8 @@ template copyBuf(data: ptr UncheckedArray[char], buf: var string,
                  idx, colStart: int): untyped =
   let nIdx = idx - colStart
   if nIdx > 0:
-    ## TODO: can we keep the buffer the same length and only copy the actual length?
-    buf = newString(nIdx)
+    buf.setLen(nIdx) # will auto reallocate if `len` is larger than capacity!
     copyMem(buf[0].addr, data[colStart].addr, nIdx)
-    buf.setLen(nIdx)
   else:
     buf.setLen(0)
 

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -80,6 +80,52 @@ suite "Column":
       else:
         check res[i, Value] == %~ "foo"
 
+  test "Adding non constant to (equal type) constant column results in native type":
+    let c1 = constantColumn(5, 5)
+    let c2 = toColumn [1, 2, 3, 4, 5]
+    check c1.len == 5
+    check c1.cCol == %~ 5
+    check c2.len == 5
+    check c2.kind == colInt
+
+    let res = add(c1, c2)
+    check res.kind == colInt
+    check res.len == 10
+    check res[0 ..< 5].toTensor(int) == [5, 5, 5, 5, 5].toTensor
+    check res[5 ..< 10].toTensor(int) == [1, 2, 3, 4, 5].toTensor
+
+  test "Adding non constant to (compatible type) constant column results in native type":
+    let c1 = constantColumn(5.0, 5)
+    let c2 = toColumn [1, 2, 3, 4, 5]
+    check c1.len == 5
+    check c1.cCol == %~ 5.0
+    check c2.len == 5
+    check c2.kind == colInt
+
+    let res = add(c1, c2)
+    check res.kind == colFloat
+    check res.len == 10
+    check res[0 ..< 5].toTensor(float) == [5.0, 5.0, 5.0, 5.0, 5.0].toTensor
+    check res[5 ..< 10].toTensor(float) == [1.0, 2.0, 3.0, 4.0, 5.0].toTensor
+
+  test "Slice assignment to constant column of compatible type leads to native column":
+    block Single:
+      var c1 = constantColumn(5, 5)
+      check c1.len == 5
+      check c1.cCol == %~ 5.0
+
+      c1[3] = 4
+      check c1.kind == colInt
+      check c1.toTensor(int) == [5, 5, 5, 4, 5].toTensor
+    block Slice:
+      var c1 = constantColumn(5, 5)
+      check c1.len == 5
+      check c1.cCol == %~ 5.0
+
+      c1[3 .. 4] = [1, 2].toTensor
+      check c1.kind == colInt
+      check c1.toTensor(int) == [5, 5, 5, 1, 2].toTensor
+
   test "Conversion of constant column results to tensor":
     let c = constantColumn(12, 40)
     check c.toTensor(0 .. 10, int) == newTensorWith(11, 12)

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -85,6 +85,172 @@ suite "Column":
     check c.toTensor(0 .. 10, int) == newTensorWith(11, 12)
     check c.toTensor(int) == newTensorWith(40, 12)
 
+  test "Lag - lag a tensor by 1 element, fill `default(T)`":
+    block Int:
+      let t = [1, 2, 3].toTensor
+      let exp = t.lag()
+      check exp.len == t.len
+      check exp[0] == 0 # default(int)
+      check exp == [0, 1, 2].toTensor
+    block Float:
+      let t = [1.0, 2.0, 3.0].toTensor
+      let exp = t.lag()
+      check exp.len == t.len
+      check exp[0] == 0.0 # default(float)
+      check exp == [0.0, 1.0, 2.0].toTensor
+    block String:
+      let t = ["1", "2", "3"].toTensor
+      let exp = t.lag()
+      check exp.len == t.len
+      check exp[0] == "" # default(string)
+      check exp == ["", "1", "2"].toTensor
+
+  test "Lag - lag a tensor by 2 element, fill `default(T)`":
+    block Int:
+      let t = [1, 2, 3].toTensor
+      let exp = t.lag(n = 2)
+      check exp.len == t.len
+      check exp[0] == 0 # default(int)
+      check exp[1] == 0 # default(int)
+      check exp == [0, 0, 1].toTensor
+    block Float:
+      let t = [1.0, 2.0, 3.0].toTensor
+      let exp = t.lag(n = 2)
+      check exp.len == t.len
+      check exp[0] == 0.0 # default(float)
+      check exp[1] == 0.0 # default(float)
+      check exp == [0.0, 0.0, 1.0].toTensor
+    block String:
+      let t = ["1", "2", "3"].toTensor
+      let exp = t.lag(n = 2)
+      check exp.len == t.len
+      check exp[0] == "" # default(string)
+      check exp[1] == "" # default(string)
+      check exp == ["", "", "1"].toTensor
+
+  test "Lag - lag a tensor by 1 element, custom fill":
+    block Int:
+      let t = [1, 2, 3].toTensor
+      let exp = t.lag(fill = int.high)
+      check exp.len == t.len
+      check exp[0] == int.high # default(int)
+      check exp == [int.high, 1, 2].toTensor
+    block Float:
+      let t = [1.0, 2.0, 3.0].toTensor
+      let exp = t.lag(fill = NaN)
+      check exp.len == t.len
+      check classify(exp[0]) == fcNaN # default(float)
+      check exp[1 .. 2] == [1.0, 2.0].toTensor
+    block String:
+      let t = ["1", "2", "3"].toTensor
+      let exp = t.lag(fill = "foo")
+      check exp.len == t.len
+      check exp[0] == "foo" # default(string)
+      check exp == ["foo", "1", "2"].toTensor
+
+  test "Lag - lag a column by 1 element, fill `default(T)`":
+    block Int:
+      let c = toColumn [1, 2, 3]
+      let exp = c.lag()
+      check exp.len == c.len
+      check exp[0, int] == 0 # default(int)
+      check exp.toTensor(int) == [0, 1, 2].toTensor
+    block Float:
+      let c = toColumn [1.0, 2.0, 3.0]
+      let exp = c.lag()
+      check exp.len == c.len
+      check exp[0, float] == 0.0 # default(float)
+      check exp.toTensor(float) == [0.0, 1.0, 2.0].toTensor
+    block String:
+      let c = toColumn ["1", "2", "3"]
+      let exp = c.lag()
+      check exp.len == c.len
+      check exp[0, string] == "" # default(string)
+      check exp.toTensor(string) == ["", "1", "2"].toTensor
+
+  test "Lead - lead a tensor by 1 element, fill `default(T)`":
+    block Int:
+      let t = [1, 2, 3].toTensor
+      let exp = t.lead()
+      check exp.len == t.len
+      check exp[2] == 0 # default(int)
+      check exp == [2, 3, 0].toTensor
+    block Float:
+      let t = [1.0, 2.0, 3.0].toTensor
+      let exp = t.lead()
+      check exp.len == t.len
+      check exp[2] == 0.0 # default(float)
+      check exp == [2.0, 3.0, 0.0].toTensor
+    block String:
+      let t = ["1", "2", "3"].toTensor
+      let exp = t.lead()
+      check exp.len == t.len
+      check exp[2] == "" # default(string)
+      check exp == ["2", "3", ""].toTensor
+
+  test "Lead - lead a tensor by 2 element, fill `default(T)`":
+    block Int:
+      let t = [1, 2, 3].toTensor
+      let exp = t.lead(n = 2)
+      check exp.len == t.len
+      check exp[1] == 0 # default(int)
+      check exp[2] == 0 # default(int)
+      check exp == [3, 0, 0].toTensor
+    block Float:
+      let t = [1.0, 2.0, 3.0].toTensor
+      let exp = t.lead(n = 2)
+      check exp.len == t.len
+      check exp[1] == 0.0 # default(float)
+      check exp[2] == 0.0 # default(float)
+      check exp == [3.0, 0.0, 0.0].toTensor
+    block String:
+      let t = ["1", "2", "3"].toTensor
+      let exp = t.lead(n = 2)
+      check exp.len == t.len
+      check exp[1] == "" # default(string)
+      check exp[2] == "" # default(string)
+      check exp == ["3", "", ""].toTensor
+
+  test "Lead - lead a tensor by 1 element, custom fill":
+    block Int:
+      let t = [1, 2, 3].toTensor
+      let exp = t.lead(fill = int.high)
+      check exp.len == t.len
+      check exp[2] == int.high # default(int)
+      check exp == [2, 3, int.high].toTensor
+    block Float:
+      let t = [1.0, 2.0, 3.0].toTensor
+      let exp = t.lead(fill = NaN)
+      check exp.len == t.len
+      check classify(exp[2]) == fcNaN # default(float)
+      check exp[0 .. 1] == [2.0, 3.0].toTensor
+    block String:
+      let t = ["1", "2", "3"].toTensor
+      let exp = t.lead(fill = "foo")
+      check exp.len == t.len
+      check exp[2] == "foo" # default(string)
+      check exp == ["2", "3", "foo"].toTensor
+
+  test "Lead - lead a column by 1 element, fill `default(T)`":
+    block Int:
+      let c = toColumn [1, 2, 3]
+      let exp = c.lead()
+      check exp.len == c.len
+      check exp[2, int] == 0 # default(int)
+      check exp.toTensor(int) == [2, 3, 0].toTensor
+    block Float:
+      let c = toColumn [1.0, 2.0, 3.0]
+      let exp = c.lead()
+      check exp.len == c.len
+      check exp[2, float] == 0.0 # default(float)
+      check exp.toTensor(float) == [2.0, 3.0, 0.0].toTensor
+    block String:
+      let c = toColumn ["1", "2", "3"]
+      let exp = c.lead()
+      check exp.len == c.len
+      check exp[2, string] == "" # default(string)
+      check exp.toTensor(string) == ["2", "3", ""].toTensor
+
 suite "DataFrame parsing":
   proc cmpElements[T](s1, s2: seq[T]): bool =
     # comparse the two seq, while properly handling `NaN`

--- a/tests/testsFormula.nim
+++ b/tests/testsFormula.nim
@@ -11,6 +11,10 @@ template fails(body: untyped): untyped =
   else:
     check true
 
+when (NimMajor, NimMinor, NimPatch) < (1, 6, 0):
+  proc isNan(x: float): bool =
+    result = classify(x) == fcNaN
+
 suite "Formulas":
   let a = [1, 2, 3]
   let b = [3, 4, 5]

--- a/tests/testsFormula.nim
+++ b/tests/testsFormula.nim
@@ -332,8 +332,6 @@ suite "Formulas":
     check exp.len == 1
     check exp["cycleStart", string][0] == "1970-01-01"
 
-import unchained
-
 suite "Formulas using the full `formula` macro":
   ## compute the number of cycles & integrated "time on" time
   ## This is still rather basic, but works now.


### PR DESCRIPTION
This is still a work in progress.

Still missing:
- [x] tests for new formula features (`formula: `, reducing formulas with explicit `for`)
- [x] tests for lead, lag
- [x] tests for constant columns and their now *non* conversion to object columns

(Initially the non-generics aspect was supposed to be part of this PR. Due to the changes being so big I still consider this `v0.2.0` instead of a minor release, among others due to a breaking change).

Full changelog:
```
* v0.2.0
- constant =DataFrame= columns have seen improvements. Before most
  operations on them would convert them to a non-constant column,
  often forced to convert to an object column. Now, most operations
  (that make sense) are supported on constants themselves and if a
  non-constant conversion is required, it aims to use the type
  corresponding to the underlying =Value= kind of the constant. That
  way conversions of constants to full columns should now lead to
  native (float, int, string, bool) tensors (unless an operation with
  another native, incompatible type is performed)
- some bugs were fixed that could cause reference semantics of
  dataframes to shine through when using =filter=
- *BREAKING*: the =toValueKind= procedure now takes a =Column= instead
  of a =ColumnKind=. This is to be able to handle the constant to full
  conversion properly. Note: A deprecated variant of the former
  version is still around!
- add =filterToIdx=, which takes a DF and a sequence / tensor of
  integers. The procedure will keep only those rows of the DF whose
  indices are part of the seq/Tensor
- slight performance improvements for the parsing of CSV files (larger
  for string heavy files) by avoiding an unnecessary =newString= call
  (yeah, =setLen= resizes for you if needed...)
- allow more valid Nim code inside of =f{}= formulas, e.g. if
  expressions and block statements
- fix type determinations in =f{}= formulas, if a procedure with
  default parameters, but no explicit type information is given.  
- certain expressions in =f{}= formulas (for example
  =isNaN(idx("foo"))=) could produce unintended CT errors and work now
  (sorry, had to add a =when compiles= check :( ).
- experimental support for "full formulas" as I call them that allow
  to have more control over variables in the scope of the formula:
  #+begin_src nim
  formula:
    preface:
      foo in df["Foo", float]
      bar in baz(df["Bar", int])
    loop:
      bar^2.float + foo  
  #+end_src
  allows for custom variable names inside of the context (and more
  importantly) to perform a full column operation (e.g. =baz=) on a
  column *before* the loop and use the elements of that operation
  inside of the loop. Note that this is _not_ for *reducing* operations
  on columns (i.e. =mean(df["Bar", float])=)! It is still planned to
  lift reducing operations out of the loop body, but that is still
  pending.
- *SEMI-BREAKING*: add preliminary support for reducing formulas that require a =for=
  loop. This (currently) allows for ~res += <formula>~ like statements
  inside of a loop instead of just ~res = <formula>~ where in the
  latter the formula must produce a scalar by itself (i.e. does not
  allow *element wise* access to columns). Now a formula that accesses
  a single element via =idx(...)= will produce a loop with an
  accumulation.
  Note: to make use of this feature you *must* use the full formula
  syntax, as otherwise the default value of =res= is unclear.
  #+begin_src nim
  formula:
    preface:
      var res = 1.0
      Bidx in df["B", float]
    loop:
      res *= Bidx * 1.5
  #+end_src
- add =lag=, =lead= procedures that take a =Tensor/Column= and return
  a new =Tensor/Column= that is shiftet forward / backward N elements
  (the left overs are zeroed by default, but adjustable using =fill= argument)
- the =showBrowser= helper to view a =DataFrame= in the browser now
  adds an additional "index" column
- improve performance of =groups= iterator (particularly in cases
  where the DF is already sorted / the sorting is cheap)
- fix type deduction issues in formulas using dot expressions for
  certain cases  
```


The following two points will be addressed at a later time, as the rest of this PR turned into more than originally planned and the non-generics stuff is much more experimental than the rest. Therefore (this badly named) PR will actually just release version `v0.1.12`.
- [ ] finish implementation of non-generic generics
- [ ] add tests for those