### PR TITLE
[io] fix parsing of fully empty CSV columns

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -15,6 +15,10 @@
   - ... whatever else you can think of. As long as it fits into a
     =Tensor[T]=, you can now place it into a DF!
   See XXX for a short introduction on the feature.
+* v0.2.2
+- fix CSV parsing for files with fully empty columns
+- allow printing of columns of kind =colNone=
+- add filename as title to =showBrowser= calls  
 * v0.2.1
 - fix regression when calling =arrange= with purely column references
   to constant columns

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -728,9 +728,11 @@ liftScalarToColumn(max)
 
 proc pretty*(c: Column): string =
   ## pretty prints a Column
-  result = &"Column of type: {toNimType(c.kind)} with length: {c.len}\n"
-  withNativeTensor(c, t):
-    result.add &"  contained Tensor: {t}"
+  result = &"Column of type: {toNimType(c.kind)} with length: {c.len}"
+  if c.kind != colNone:
+    result.add "\n"
+    withNativeTensor(c, t):
+      result.add &"  contained Tensor: {t}"
 template `$`*(c: Column): string = pretty(c)
 
 proc clone*(c: Column): Column =

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -668,6 +668,8 @@ tr:nth-child(even) {
 </head>
 <body>
 
+<h2> $# </h2>
+
 <table>
   $#
 </table>
@@ -695,7 +697,7 @@ tr:nth-child(even) {
     inc idx
   body.add "</tbody>"
   let fname = path / fname
-  writeFile(fname, tmpl % [header & body])
+  writeFile(fname, tmpl % [fname, header & body])
   openDefaultBrowser(fname)
   if toRemove:
     # opening browsers may be slow, so wait a long time before we delete (file still needs to

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -485,6 +485,7 @@ proc readCsvTypedImpl(data: ptr UncheckedArray[char],
   # file if it contains only empty values in one column. After N > 20? 50? whatever rows we can
   # reasonably argue it will likely be an object column. Otherwise the user can reconvert back to native
   # should be the saner default
+  # Note: for a *fully* empty column, we *could* also assign a constant value of VNull
   if not allColTypesSet(colTypes):
     for c in mitems(colTypes):
       if c == colNone:

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -479,6 +479,17 @@ proc readCsvTypedImpl(data: ptr UncheckedArray[char],
   idx = lastIdx
   colStart = lastColStart
   row = lastRow
+
+  # 2b. if one column was *completely* empty, turn it into colObject
+  # TODO: The `while` above should break after N lines. Otherwise we risk running over the whole
+  # file if it contains only empty values in one column. After N > 20? 50? whatever rows we can
+  # reasonably argue it will likely be an object column. Otherwise the user can reconvert back to native
+  # should be the saner default
+  if not allColTypesSet(colTypes):
+    for c in mitems(colTypes):
+      if c == colNone:
+        c = colObject
+
   # 3. create the starting columns
   var cols = newSeq[Column](numCols)
   let dataLines = lineCnt - skippedLines

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -427,6 +427,25 @@ b,,foo
         checkBlock()
         removeFile(path)
 
+  test "Parsing with fully column":
+    ## Reported by @KosKosynsky on the Nim #science channel
+    let data = """,ID of record,Record number,date_from,date_to,(Name) Additional name if exists,Canal
+0,29528,173/MZS/2020,2020/08-04,2021-08-03,,DE
+1,29529,113/KEK/1443,2020-08-11,2021-08-10,,DE
+2,29530,148/BBK/1527,2020-08-12,2021-08-11,,DE
+3,29531,159/ROT/2769,2020-08-13,2021-08-12,,DE
+4,29532,745/REZ/3265,2020-08-20,2021-08-19,,DE
+5,29533,158/GTK/2144,2020/08-25,2021-0824,,DE
+6,29534,151/ZEB/1654,2020-08-28,2021-08-27,,DE
+7,29535,158/MTG/6526,2020-08-23,2021-08-22,,DE
+"""
+    let df = parseCsvString(data)
+    check df.getKeys.len == 7
+    check "(Name) Additional name if exists" in df
+    check "Unnamed0" in df
+    check df["(Name) Additional name if exists"].kind == colObject
+    check df["(Name) Additional name if exists", Value][0] == null()
+
 suite "DataFrame tests":
 
   test "`toDf` is no-op for DF":


### PR DESCRIPTION
If a column is completely empty, it should still correctly parse it
into a `colObject` filled with `VNull`.

- [x] add test case for such data
- [ ] stop guessing type if more than N rows at beginning empty ⇐ will be done in the future