### PR TITLE
Respect order of arguments to `select`, add `relocate`

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -15,6 +15,11 @@
   - ... whatever else you can think of. As long as it fits into a
     =Tensor[T]=, you can now place it into a DF!
   See XXX for a short introduction on the feature.
+* v0.2.3
+- =select= now respects the order of the given columns, i.e. the order
+  of the columns in the resulting DF are in the order of the given
+  columns
+- add =relocate= to change the column order of one or more keys
 * v0.2.2
 - fix CSV parsing for files with fully empty columns
 - allow printing of columns of kind =colNone=

--- a/changelog.org
+++ b/changelog.org
@@ -20,6 +20,8 @@
   of the columns in the resulting DF are in the order of the given
   columns
 - add =relocate= to change the column order of one or more keys
+- add experimental operation to access column at index =i= using
+  =df[[i]]= syntax
 * v0.2.2
 - fix CSV parsing for files with fully empty columns
 - allow printing of columns of kind =colNone=

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1307,7 +1307,7 @@ proc select*[T: string | FormulaNode](df: DataFrame, cols: varargs[T]): DataFram
     assignFormulaCol(result, df, k)
   if df.kind == dfGrouped:
     # check that groups are still in the DF, else raise
-    let grps = df.groupMap.keys.toSeq
+    let grps = toSeq(keys(df.groupMap))
     if not grps.allIt(it in result):
       raise newException(ValueError, "Cannot select off (drop) a column the input data frame is grouped by!")
 

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1270,7 +1270,7 @@ proc assignFormulaCol[T: string | FormulaNode](df: var DataFrame, frm: DataFrame
     of fkAssign:
       df[key.lhs] = frm[key.rhs]
     else:
-      raise newException(FormulaMismatchError, "Formula `" & $fn & "` of kind `" & $fn.kind & "` not allowed " &
+      raise newException(FormulaMismatchError, "Formula `" & $key & "` of kind `" & $key.kind & "` not allowed " &
         "for selection.")
 
 proc select*[T: string | FormulaNode](df: DataFrame, cols: varargs[T]): DataFrame =
@@ -1341,9 +1341,9 @@ proc removeColumns[T: string | FormulaNode](keys: var seq[string], cols: seq[T])
         let col = key.val.toStr
         removeStr(keys, col)
       of fkAssign:
-        removeStr(keys, key.rhs)
+        removeStr(keys, key.rhs.toStr)
       else:
-        raise newException(FormulaMismatchError, "Formula `" & $fn & "` of kind `" & $fn.kind & "` not allowed " &
+        raise newException(FormulaMismatchError, "Formula `" & $key & "` of kind `" & $key.kind & "` not allowed " &
           "for selection.")
 
 proc relocate*[T: string | FormulaNode](df: DataFrame, cols: varargs[T], after = "", before = ""): DataFrame =

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -204,6 +204,15 @@ proc `[]`*[T](df: DataFrame, key: string, dtype: typedesc[T]): Tensor[T] =
     doAssert t.sum == 15
   result = df.data[key].toTensor(dtype)
 
+proc `[]`*(df: DataFrame, idx: array[1, int]): Column =
+  ## Returns the column at index `idx`.
+  ##
+  ## NOTE: experimental!
+  let j = idx[0]
+  doAssert j >= 0 and j < df.ncols
+  for i, k in df.getKeys:
+    if i == j: return df[k]
+
 proc get*(df: DataFrame, key: string): Column {.inline.} =
   ## Returns the column of `key`.
   ##

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -209,6 +209,8 @@ proc `[]`*(df: DataFrame, idx: array[1, int]): Column =
   ##
   ## NOTE: experimental!
   let j = idx[0]
+  if j < 0 or j >= df.ncols:
+    raise newException(IndexError, "Index " & $j & " is out of bounds for DF with " & $df.ncols & " columns.")
   doAssert j >= 0 and j < df.ncols
   for i, k in df.getKeys:
     if i == j: return df[k]

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -452,7 +452,7 @@ suite "DataFrame tests":
     let df = toDf(toDf(readCsv("data/mpg.csv")))
     check df["class", string] == readCsv("data/mpg.csv")["class", string]
 
-  test "`toDf` is works on an OrderedTable[string, seq[string]]":
+  test "`toDf` works on an OrderedTable[string, seq[string]]":
     var tab = initOrderedTable[string, seq[string]]()
     tab["x"] = @["1", "2"]
     tab["y"] = @["4", "5"]
@@ -460,7 +460,7 @@ suite "DataFrame tests":
     check df["x", int] == [1, 2].toTensor
     check df["y", int] == [4, 5].toTensor
 
-  test "`toDf` is works on an OrderedTable[string, seq[Value]]":
+  test "`toDf` works on an OrderedTable[string, seq[Value]]":
     var tab = initOrderedTable[string, seq[Value]]()
     tab["x"] = @[%~ 1, %~ 2]
     tab["y"] = @[%~ 4, %~ 5]
@@ -468,13 +468,13 @@ suite "DataFrame tests":
     check df["x", int] == [1, 2].toTensor
     check df["y", int] == [4, 5].toTensor
 
-  test "`toDf` is works for a single identifier":
+  test "`toDf` works for a single identifier":
     let x = @[1, 2, 3]
     let df = toDf(x)
     check "x" in df
     check df["x", int] == [1, 2, 3].toTensor
 
-  test "`toDf` is works for multiple identifiers":
+  test "`toDf` works for multiple identifiers":
     let x = @[1, 2, 3]
     let y = @[4, 5, 6]
     let df = toDf(x, y)
@@ -483,14 +483,14 @@ suite "DataFrame tests":
     check "y" in df
     check df["y", int] == [4, 5, 6].toTensor
 
-  test "`toDf` is works for a single call":
+  test "`toDf` works for a single call":
     proc foo(): seq[int] =
       result = @[1, 2, 3]
     let df = toDf(foo())
     check "foo()" in df
     check df["foo()", int] == [1, 2, 3].toTensor
 
-  test "`toDf` is works for multiple calls":
+  test "`toDf` works for multiple calls":
     proc foo(): seq[int] =
       result = @[1, 2, 3]
     proc bar(): seq[string] =
@@ -501,13 +501,13 @@ suite "DataFrame tests":
     check "bar()" in df
     check df["bar()", string] == ["a", "b", "c"].toTensor
 
-  test "`toDf` is works for a single TableConstr element":
+  test "`toDf` works for a single TableConstr element":
     let x = @[1, 2, 3]
     let df = toDf({"x" : x})
     check "x" in df
     check df["x", int] == [1, 2, 3].toTensor
 
-  test "`toDf` is works for multiple TableConstr elements":
+  test "`toDf` works for multiple TableConstr elements":
     let x = @[1, 2, 3]
     let y = @[4, 5, 6]
     let df = toDf({"x" : x, "y" : y})
@@ -516,14 +516,14 @@ suite "DataFrame tests":
     check "y" in df
     check df["y", int] == [4, 5, 6].toTensor
 
-  test "`toDf` is works for a single call in a TableConstr":
+  test "`toDf` works for a single call in a TableConstr":
     proc foo(): seq[int] =
       result = @[1, 2, 3]
     let df = toDf({"x" : foo()})
     check "x" in df
     check df["x", int] == [1, 2, 3].toTensor
 
-  test "`toDf` is works for multiple calls in a TableConstr":
+  test "`toDf` works for multiple calls in a TableConstr":
     proc foo(): seq[int] =
       result = @[1, 2, 3]
     proc bar(): seq[string] =


### PR DESCRIPTION
- `select` now respects the users order of the given column. 
- adds `relocate` to change the order of columns in a DF
- adds an experimental operator to access column at integer index using `[[idx]]`, i.e. `df[[2]]` returns column at index 2


- [x] write tests