### PR TITLE
More doc and misc fixes

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,4 +1,4 @@
-* v0.3.0 (To be finalized...)
+* +v0.3.0 (To be finalized...)+ (ON ICE)
 - *MAJOR, BREAKING*: Add experimental support for "non-generic generic
   =Columns=". Essentially, from many procedures it is now possible to
   assign data types that are normally not supported to be stored
@@ -15,6 +15,23 @@
   - ... whatever else you can think of. As long as it fits into a
     =Tensor[T]=, you can now place it into a DF!
   See XXX for a short introduction on the feature.
+
+* v0.2.4
+- replace an assertion by a proper check in =summarize= if user hands
+  a non reducing formula to it
+- replace usages of =seqsToDf= in the docs
+- *BREAKING*: in =readCsv= the =colNames= argument, if any are given,
+  now implies we _skip_ the parsing of the header completely. If there
+  _is_ a header in the file that is to be ignored, =colNames= must be
+  combined with =skipLines=! See also the updated docstring.
+- possibly breaking: when parsing CSV files with space / tab separators, spacing at the
+  end of the lines does not cause issues anymore (they previously
+  caused us to count them as real columns, meaning possible crashes
+  due to number of column mismatches). This _can_ be breaking for a
+  user, but in that case they relied on unspecified behavior. Empty
+  columns at the beginning or ending in the file are a bit crazy for
+  space based seps. However, we might add a =skipInitialSpace=
+  equivalent for this in the future.
 * v0.2.3
 - =select= now respects the order of the given columns, i.e. the order
   of the columns in the resulting DF are in the order of the given

--- a/docs/datamancer.org
+++ b/docs/datamancer.org
@@ -117,11 +117,11 @@ optimizations applicable to the specific domain.
 *** From =seq[T]/Tensor[T]=
 
 For the case of having the data as =seq[T]=, we just use the
-=seqsToDf= template to create a DF from it. The template does not care
+=toDf= template to create a DF from it. The template does not care
 whether the input is of type =seq[T]= or =Tensor[T]=. In the future
 support for pointer + length pairs can be added as well.
 
-There are two ways to use =seqsToDf=. Assuming we have three sequences of possibly different types:
+There are two ways to use =toDf=. Assuming we have three sequences of possibly different types:
 #+BEGIN_SRC nim
 let s1: seq[int] = @[22, 54, 34]
 let s2: seq[float] = @[1.87, 1.75, 1.78]
@@ -130,7 +130,7 @@ let s3: seq[string] = @["Mike", "Laura", "Sue"]
 we can either create a DF and let the library automatically deduce the
 column names from the Nim identifiers of the given variables:
 #+BEGIN_SRC nim
-let dfAutoNamed = seqsToDf(s1, s2, s3)
+let dfAutoNamed = toDf(s1, s2, s3)
 #+END_SRC
 which will give us a DF with column names:
 #+BEGIN_SRC nim
@@ -139,9 +139,9 @@ which will give us a DF with column names:
 In many cases one might rather like a different name. In this case use the following
 syntax:
 #+BEGIN_SRC nim
-let df = seqsToDf({ "Age" : s1,
-                    "Height" : s2,
-                    "Name" : s3 })
+let df = toDf({ "Age" : s1,
+                "Height" : s2,
+                "Name" : s3 })
 #+END_SRC
 which will then use the given strings for the column names.
 

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1874,7 +1874,9 @@ proc summarize*(df: DataFrame, fns: varargs[FormulaNode]): DataFrame =
   case df.kind
   of dfNormal:
     for fn in fns:
-      doAssert fn.kind == fkScalar
+      if fn.kind != fkScalar:
+        raise newException(FormulaMismatchError, "The given formula `" & $fn.name & "` of kind `" & $fn.kind &
+          "` is not a scalar formula. Did you forget to apply a reducing procedure to the arguments?")
       lhsName = fn.valName
       # just apply the function
       withNativeConversion(fn.valKind, get):
@@ -1889,7 +1891,9 @@ proc summarize*(df: DataFrame, fns: varargs[FormulaNode]): DataFrame =
     var idx = 0
     var keyLabelsAdded = false
     for fn in fns:
-      doAssert fn.kind == fkScalar
+      if fn.kind != fkScalar:
+        raise newException(FormulaMismatchError, "The given formula " & $fn.name & " of kind " & $fn.kind &
+          " is not a scalar formula. Did you forget to apply a reducing procedure to the arguments?")
       lhsName = fn.valName
       sumStats[lhsName] = newSeqOfCap[Value](1000) # just start with decent size
       for class, subdf in groups(df):

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -466,6 +466,8 @@ proc readCsvTypedImpl(data: ptr UncheckedArray[char],
       guessType(data, buf, colTypes, col, idx, colStart, numCols)
       # if we see the end of the line, store the current column number
       if data[idx] in {'\n', '\r', '\l'}:
+        if lastWasSep and sep in {' ', '\t'}:
+          dec col # don't count "empty space columns" at end
         dataColsIdx = col
         if not allColTypesSet(colTypes): # manually perform steps to go to next line and skip
                                          # `when toBreak` logic

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -544,6 +544,13 @@ proc readCsv*(fname: string,
   ##
   ## `skipLines` is used to skip `N` number of lines at the beginning of the
   ## file.
+  ##
+  ## `colNames` can be used to overwrite (or supply if none in file!) names of the
+  ## columns in the header. This is also useful if the header is not conforming
+  ## to the separator of the file. Note: if you `do` supply custom column names,
+  ## but there `is` a header in the file, make sure to use `skipLines` to skip
+  ## that header, as we will not try to parse any header information if `colNames`
+  ## is supplied.
   result = newDataFrame()
   var ff = memfiles.open(fname)
   var lineCnt = 0

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -340,7 +340,7 @@ template parseCol(data: ptr UncheckedArray[char], buf: var string,
 template advanceToNextRow() {.dirty.} =
   ## The steps done after a line break is found & we advance to the next row.
   ##
-  ## Stored in a dity template as we also use it while guessing types.
+  ## Stored in a dirty template as we also use it while guessing types.
   inc row
   col = 0
   if data[idx] == '\r' and data[idx + 1] == '\l':

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -421,10 +421,11 @@ proc readCsvTypedImpl(data: ptr UncheckedArray[char],
     buf = newStringOfCap(80)
 
   # 1. first parse the header
-  var colNames: seq[string]
-  while idx < size:
-    parseLine(data, buf, sep, quote, col, idx, colStart, row, rowStart, lastWasSep, inQuote, toBreak = true):
-      parseHeaderCol(data, buf, colNames, header, sep, quote, idx, colStart)
+  var colNames = colNamesIn
+  if colNames.len == 0:
+    while idx < size:
+      parseLine(data, buf, sep, quote, col, idx, colStart, row, rowStart, lastWasSep, inQuote, toBreak = true):
+        parseHeaderCol(data, buf, colNames, header, sep, quote, idx, colStart)
 
   if colNamesIn.len > 0 and colNamesIn.len != colNames.len:
     raise newException(IOError, "Input data contains " & $colNames.len & " columns, but " &

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1272,6 +1272,15 @@ t_in_s,  C1_in_V,  C2_in_V,  type
         for el in dfG[$f{int: sum(c"numVec")}].toTensor(Value):
           check el == %~ sumNum
 
+    block:
+      let df = seqsToDf({"x": @[1, 2, 3, 4, 5], "y": @[5, 10, 15, 20, 25]})
+      try:
+        # fails with `FormulaMismatchError` as there is no reducing proc call in
+        # the formula body!
+        echo df.summarize(f{float: `x`})
+      except FormulaMismatchError:
+        discard
+
   test "Count":
     # count elements by group. Useful combination of group_by and summarize(len)
     let mpg = readCsv("data/mpg.csv")


### PR DESCRIPTION
Fixes an issue reported by ezquerra on the #science channel (`summarize` erroring with an assertion error instead of a proper error message if a non reducing formula was handed).

In addition fixes a few issues with `readCsv` and fixes up the docs to use `toDf` instead of `seqsToDf`.

- [x] add tests for `colNames`
- [x] add tests for empty space in space sep'd CSV parsing