### PR TITLE
improve `rename` safety & change `<-` meaning in `mutate`, change DF print width

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -15,6 +15,20 @@
   - ... whatever else you can think of. As long as it fits into a
     =Tensor[T]=, you can now place it into a DF!
   See XXX for a short introduction on the feature.
+* v0.2.8
+- *BREAKING*: change semantics of assignment formula (using =<-=) in
+  the context of =mutate=. Previously, using such formulas in a
+  =mutate= (or =transmute=) call would end up renaming a column from
+  RHS to LHS. However, this was never clearly communicated & was a bit
+  unclear. In particular it made it impossible to generate a constant
+  column in a =mutate= call, which seems much more useful to me.
+  To rename a column, simply use the =rename= procedure as
+  before. Note that a =f{"bar" <- "foo"}= formula is required in that
+  case.
+- raise an exception in =rename= if a formula of different kind than
+  =fkAssign= is given
+- change default printing width of columns in a DF. Make them a bit
+  wider to accommodate float columns printed in exp notation.
 * v0.2.7
 - another quick release to help with some windows line ending CSV
   files

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -498,9 +498,9 @@ macro toTab*(args: varargs[untyped]): untyped =
       let aName = a.toStrLit
       result.add quote do:
         `asgnSym`(`data`, `aName`, `a`)
-
   result = quote do:
     block:
+      mixin extendShortColumns
       `result`
       # finally fill up possible columns shorter than df.len
       `data`.extendShortColumns()

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1568,10 +1568,14 @@ proc rename*(df: DataFrame, cols: varargs[FormulaNode]): DataFrame =
 
   result = df
   for fn in cols:
-    doAssert fn.kind == fkAssign
-    result[fn.lhs] = df[fn.rhs.toStr]
-    # remove the column of the old name
-    result.drop(fn.rhs.toStr)
+    if fn.kind == fkAssign:
+      result[fn.lhs] = df[fn.rhs.toStr]
+      # remove the column of the old name
+      result.drop(fn.rhs.toStr)
+    else:
+      raise newException(FormulaMismatchError, "To rename columns use a formula " &
+        "of kind `fkAssign`, i.e. `\"foo\" <- \"bar\"`. Given formula " & $fn &
+        "is of kind `" & $fn.kind & "`.")
 
 proc arrangeSortImpl[T](toSort: var seq[(int, T)], order: SortOrder) =
   ## sorts the given `(index, Value)` pair according to the `Value`

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -715,7 +715,11 @@ proc pretty*(df: DataFrame, numLines = 20, precision = 4, header = true): string
   ## `pretty` is called by `$` with the default parameters.
   # TODO: need to improve printing of string columns if length of elements
   # more than `alignBy`.
-  var maxLen = 6 # default width for a column name
+
+  ## XXX: should columns of different types have different default widths? e.g. float being
+  ## at least 9 chars, ints X, strings Y ?
+  ## maybe can also look at data if DF not too long and/or we only print `numLines << 1e9` elements?
+  var maxLen = 9 # default width for a column name
   for k in keys(df):
     maxLen = max(k.len, maxLen)
   if header:

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1500,10 +1500,10 @@ proc mutate*(df: DataFrame, fns: varargs[FormulaNode]): DataFrame =
         f{"bar" <- "x"}, # generates a constant column with value "x", does *not* rename "x" to "bar"
         f{"baz" ~ 2}     # generates a (non-constant!) column of only values 2
       )
-      doAssert df["foo"].kind == colConstant
-      doAssert df["bar"].kind == colConstant
-      doAssert "x" in df # "x" untouched
-      doAssert df["baz"].kind == colInt # integer column, not constant!
+      doAssert dfRes["foo"].kind == colConstant
+      doAssert dfRes["bar"].kind == colConstant
+      doAssert "x" in dfRes # "x" untouched
+      doAssert dfRes["baz"].kind == colInt # integer column, not constant!
 
   result = df.shallowCopy()
   result.mutateInplace(fns)


### PR DESCRIPTION
+Many procedures are now marked as `{.gcsafe.}` which previously would cause issues in a multithreaded context ("cannot be called, as it's not gcsafe").+

Further we now raise an exception if `rename` is used with a formula different than `<-`.

Finally, and this is a *breaking* change, the meaning of `<-` in a `mutate` call has changed. Before this would simply also amount to a `rename` in case that the column on the RHS actually existed. Now, `<-` is *only* used to denote generating a constant column of the name LHS with value RHS. This makes it actually possible to construct constant columns from `mutate` instead of having to do the following ugly hack:
```nim
var df = getSomeDf().mutate(f{...}) # regular mutate call with some calculations
df["someConstant"] = 5
```
to get a `someConstant` column with value 5. Instead now:
```nim
let df = getSomeDf().mutate(
  f{...}, # same calcs as before
  f{"someConstant" <- 5}
)
```

If the RHS contains a string value referring to a column *this is ignored*. It *always* constructs a constant column of the name LHS with value RHS!

edit:
And the default width for printing a DF was changed from 6 + precision to 9 + precision to accommodate floats in exp notation. These would previously always be cut off and even increasing the precision did not help (as it would also increase the size of the float string).

edit 2: the `{.gcsafe.}` is imo a dead end. It causes way too many problems. In many cases just capturing a local variable will already be enough to trigger an unsafe warning. Not for me, at least not now..