### PR TITLE
`readCsv` hotfix for files where we fail to determine column types

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -16,6 +16,15 @@
     =Tensor[T]=, you can now place it into a DF!
   See XXX for a short introduction on the feature.
 
+* v0.2.6
+- hotfix release fixing an issue with =readCsv=.
+  - if a file contained columns that do not allow us to determine
+    types, fixes an issue in which parsing of them failed, due to a
+    missing reset of =col=
+  - add a =maxGuesses= argument to =readCsv= to stop guessing types
+    after this many rows (set to 'object' columns in that case)
+  - fix a small issue in which we always entered the =skipLines= loop,
+    even if we didn't have to skip any lines
 * v0.2.5
 - add support for reading CSV files from http and https URLs.
 - do not ignore `skipInitialSpace` and `quote` readCsv arguments.

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -448,10 +448,11 @@ proc readCsvTypedImpl(data: ptr UncheckedArray[char],
   let numCols = colNames.len
   # 1b. skip `skipLines`
   let rowDataStart = row
-  while idx < size:
-    parseLine(data, buf, sep, quote, col, idx, colStart, row, rowStart, lastWasSep, inQuote, toBreak = false):
-      if row - rowDataStart == skipLines:
-        break
+  if skipLines > 0:
+    while idx < size:
+      parseLine(data, buf, sep, quote, col, idx, colStart, row, rowStart, lastWasSep, inQuote, toBreak = false):
+        if row - rowDataStart == skipLines:
+          break
   # compute the number of skipped lines in total
   let skippedLines = row
   # reset row to 0

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -482,6 +482,7 @@ proc readCsvTypedImpl(data: ptr UncheckedArray[char],
     raise newException(IOError, "Input data contains " & $(dataColsIdx + 1) & " in the data portion, but " &
       $numCols & " columns in the header.")
   # 2a. revert the indices (make it a peek)
+  col = 0 # reset `col` to 0 regardless
   idx = lastIdx
   colStart = lastColStart
   row = lastRow


### PR DESCRIPTION
A small hotfix release fixing a bug in `readCsv` for certain input files:

Changelog:

```
* v0.2.6
- hotfix release fixing an issue with =readCsv=.
  - if a file contained columns that do not allow us to determine
    types, fixes an issue in which parsing of them failed, due to a
    missing reset of =col=
  - add a =maxGuesses= argument to =readCsv= to stop guessing types
    after this many rows (set to 'object' columns in that case)
  - fix a small issue in which we always entered the =skipLines= loop,
    even if we didn't have to skip any lines
```