### PR TITLE
Fix formula regression and `toColumn` for scalars

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.3.2
+- fix regression in =ggplotnim= formula due to badly determined result
+  type. Only use resulting type of =Preface= if type acceptable (e.g. not generic)
 * v0.3.1
 - keep conversions from other number types to =int= and =float= after
   all in the context of =toDf= and =toColumn=.

--- a/changelog.org
+++ b/changelog.org
@@ -1,6 +1,8 @@
 * v0.3.2
 - fix regression in =ggplotnim= formula due to badly determined result
-  type. Only use resulting type of =Preface= if type acceptable (e.g. not generic)
+  type. Only use resulting type of =Preface= if type acceptable
+  (e.g. not generic)
+- fix =toColumn= for single element =Column= construction  
 * v0.3.1
 - keep conversions from other number types to =int= and =float= after
   all in the context of =toDf= and =toColumn=.

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -238,10 +238,6 @@ proc toColumn*[T: SupportedTypes](s: openArray[T]): Column =
     vals[i] = x
   result = toColumn(vals)
 
-proc toColumn*(s: string): Column =
-  ## explicit string overload so that it doesn't match the above `openArray[T]` call
-  result = constantColumn(s, 1)
-
 proc toColumn*[T: SupportedTypes](x: T): Column =
   ## Turn a single scalar element of the supported types into a regular `Column`.
   ## If a single `Value` is handed, we convert to the native underlying type.

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -1170,7 +1170,9 @@ macro compileFormulaImpl*(rawName: static string,
 
   fct.resType = if fct.typeHint.resType.isSome:
                   fct.typeHint.resType.get
-                elif resTypeFromSymbols.kind != nnkEmpty and allAgree and typ.resType.isSome:
+                elif resTypeFromSymbols.kind != nnkEmpty and allAgree and
+                     typ.resType.isSome and
+                     fct.preface.resType.typeAcceptable: # the determined type must be acceptable (i.e. not generic)
                   # Take the highest priority type between symbol deduced one and
                   # heuristic one
                   let typOrdered = sortTypes(

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -758,7 +758,7 @@ tr:nth-child(even) {
   header = "<thead>\n<tr>"
   header.add &"<th> Index </th>"
   for k in df.getKeys:
-    header.add &"<th> {k} <br><br> {df[k].kind.toNimType} </th>"
+    header.add &"<th> {k} <br><br> {df[k].toNimType} </th>"
   header.add "</tr>\n</thead>"
   body = "<tbody>"
   var idx = 0

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -16,6 +16,50 @@ suite "Column":
     for i in 0 ..< c.len:
       check c[i, int] == 12
 
+  test "Column form a scalar":
+    block Int:
+      let x = 1
+      let c = toColumn x
+      check c.kind == colInt
+      check c.toTensor(int) == [1].toTensor
+    block Float:
+      let x = 1.0
+      let c = toColumn x
+      check c.kind == colFloat
+      check c.toTensor(float) == [1.0].toTensor
+    block String:
+      let x = "1"
+      let c = toColumn x
+      check c.kind == colString
+      check c.toTensor(string) == ["1"].toTensor
+    block Bool:
+      let x = true
+      let c = toColumn x
+      check c.kind == colBool
+      check c.toTensor(bool) == [true].toTensor
+
+  test "Column from scalar Value yields native":
+    block Int:
+      let x = %~ 1
+      let c = toColumn x
+      check c.kind == colInt
+      check c.toTensor(int) == [1].toTensor
+    block Float:
+      let x = %~ 1.0
+      let c = toColumn x
+      check c.kind == colFloat
+      check c.toTensor(float) == [1.0].toTensor
+    block String:
+      let x = %~ "1"
+      let c = toColumn x
+      check c.kind == colString
+      check c.toTensor(string) == ["1"].toTensor
+    block Bool:
+      let x = %~ true
+      let c = toColumn x
+      check c.kind == colBool
+      check c.toTensor(bool) == [true].toTensor
+
   test "Adding two equal constant columns":
     let c1 = constantColumn(12, 40)
     let c2 = constantColumn(12, 60)

--- a/tests/testsFormula.nim
+++ b/tests/testsFormula.nim
@@ -336,6 +336,16 @@ suite "Formulas":
     check exp.len == 1
     check exp["cycleStart", string][0] == "1970-01-01"
 
+  test "Regression from ggplotnim recipe formula":
+    # should deduce to float
+    let fn = f{c"spikes" - c"lineSize" / 2.0}
+    check $fn == "(- spikes (/ lineSize 2.0))"
+    check fn.kind == fkVector
+    let df = toDf({"spikes" : @[1, 2], "lineSize" : @[2, 4]})
+    let res = fn.evaluate(df)
+    check res.kind == colFloat
+    check res.toTensor(int) == @[0, 0].toTensor # compare as int for simplicity
+
 suite "Formulas using the full `formula` macro":
   ## compute the number of cycles & integrated "time on" time
   ## This is still rather basic, but works now.


### PR DESCRIPTION
```
* v0.3.2
- fix regression in =ggplotnim= formula due to badly determined result
  type. Only use resulting type of =Preface= if type acceptable (e.g. not generic)
```