### PR TITLE
Misc generic improvements

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -5,7 +5,10 @@
 - minor cleanup of macro logic
 - rename =genColumn= to =defColumn=
 - =toDf= now supports assignment of generic arguments as well, as long
-  as the column type required has been generated already.      
+  as the column types required have been generated already.
+- =defColumn= now generates all combinations of the given types
+- fixes some issues with =unionType= getting confused
+- makes =toColumn= work correctly with =array=  
 * v0.3.2
 - fix regression in =ggplotnim= formula due to badly determined result
   type. Only use resulting type of =Preface= if type acceptable

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,11 @@
+* v0.3.3
+- define =ScalarLike= concept to match types that can be converted to
+  =float= via =.float= for e.g. units to have a =%~= Value conversion
+  for them
+- minor cleanup of macro logic
+- rename =genColumn= to =defColumn=
+- =toDf= now supports assignment of generic arguments as well, as long
+  as the column type required has been generated already.      
 * v0.3.2
 - fix regression in =ggplotnim= formula due to badly determined result
   type. Only use resulting type of =Preface= if type acceptable

--- a/playground/non_generic_generics.nim
+++ b/playground/non_generic_generics.nim
@@ -9,17 +9,13 @@ import tables, sets # not needed if not called from here `patchDataFrame`
 
 {.experimental: "overloadableEnums".}
 
-proc `%~`[T: SomeUnit](m: T): Value =
-  result = newVObject()
-  result[$T] = (%~ m.float)
-
 proc makeCol[T](s: seq[T]) =
   var c = toColumn(s.toTensor)
   echo pretty(c)
 
 #var t = toTensor(@[2.kg])
-genColumn(KiloGram)
-genColumn(Measurement[float])
+defColumn(KiloGram)
+defColumn(Measurement[float])
 block:
   let ti = @[1.kg, 2.kg].toTensor
   var c = toColumn(ti)
@@ -51,7 +47,7 @@ echo typeof(fn)
 defUnit(kg²)
 #genTypeEnum(KiloGram²)
 #type kg2Col = patchColumn(KiloGram²)
-genColumn(Meter)
+defColumn(Meter)
 #genTypeEnum(Meter)
 #type mCol = patchColumn(Meter)
 
@@ -65,11 +61,11 @@ echo dfN.pretty(precision = 10)
 echo dfN.arrange("kg", SortOrder.Descending).pretty(precision = 10)
 echo dfN.arrange("kg", SortOrder.Ascending).pretty(precision = 10)
 
-genColumn(KiloGram, KiloGram²)
+defColumn(KiloGram, KiloGram²)
 let fn2 = dfFn(dfN, f{KiloGram -> KiloGram²: "kg2" ~ `kg` * `kg`})
 echo typeof(fn2)
 #
-genColumn(KiloGram, Meter)
+defColumn(KiloGram, Meter)
 ##genTypeEnum(KiloGram, Meter)
 ##type ttCol = patchColumn(KiloGram, Meter)
 let dfNM = extendDataFrame(dfN, "meter", @[1.m, 2.m, 3.m])
@@ -87,7 +83,7 @@ type
     x: string
     val: float
 proc `<`(f1, f2: Foo): bool = f1.val < f2.val
-genColumn(Foo)
+defColumn(Foo)
 # accumulating types works to call mutate w/o df arg
 var dFoo = colType(Foo).newDataTable()
 dFoo["bar"] = @[Foo(x: "hello", val: 1.1), Foo(x: "world", val: 100.5)]
@@ -96,6 +92,6 @@ echo dFoo.pretty(precision = 30)
 
 # extend simply by accumulating types
 ## WARNING: generating a column for a type that is an alias may cause problems!
-genColumn(KiloGram²)
+defColumn(KiloGram²)
 let df2 = df.mutate(f{int: "kg²" ~ `x`.kg²})
 echo df2

--- a/src/datamancer/ast_utils.nim
+++ b/src/datamancer/ast_utils.nim
@@ -32,3 +32,14 @@ import macrocache
 proc contains*(t: CacheTable, key: string): bool =
   for k, val in pairs(t):
     if k == key: return true
+
+from sequtils import deduplicate
+proc combinations*(s: seq[NimNode]): seq[seq[NimNode]] =
+  ## inefficient combinatorics calculator. Used to generate all type combinations
+  if s.len > 0:
+    result.add s
+  for x in s:
+    var sNoX = s
+    sNoX.delete(s.find(x))
+    result.add combinations(sNoX)
+  result = result.deduplicate()

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -38,15 +38,15 @@ import macrocache
 const TypeNames = CacheTable"ColTypeNames"
 
 macro unionType*(t1, t2: typed): untyped =
-  let t1I = t1.getInnerType()
-  let t2I = t2.getInnerType()
-  let ts = genColNameStr(@[t1I, t2I])
+  let t1I = t1.getInnerType().columnToTypes()
+  let t2I = t2.getInnerType().columnToTypes()
+  let ts = genColNameStr(concat(t1I, t2I))
   if ts in TypeNames:
     result = TypeNames[ts]
   else:
     # generate?
-    ## XXX: strip the `Column` from type names
-    error("Please generate the type using `patchColumn(" & $t1I.repr & ", " & $t2I.repr & ")` before using it.")
+    error("The type " & $ts & " does not exist yet. Please generate it using `defColumn(" &
+      $t1I.repr & ", " & $t2I.repr & ")` before using it.")
 
 # ---------- Simple 1 line helper procs ----------
 template ncols*[C: ColumnLike](df: DataTable[C]): int =

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -1085,6 +1085,7 @@ proc parseOptionValue(n: NimNode): Option[FormulaKind] {.used.} =
     error("Bad input node " & $n.repr & " in `parseOptionValue`.")
 
 import macrocache # needed only here
+const TypeNames = CacheTable"ColTypeNames"
 proc genClosureRetType(preface: Preface, resType: NimNode, dfType: Option[NimNode]): NimNode =
   let typs = if dfType.isSome:
                dfType.get.columnToTypes()
@@ -1096,7 +1097,6 @@ proc genClosureRetType(preface: Preface, resType: NimNode, dfType: Option[NimNod
     error("The column type `" & $name & "` has not been generated yet. If you haven't added " &
       "a column using this type to a DF yet, call `patchColumn` with the type.")
   result = TypeNames[name]
-
 
 macro compileFormulaImpl*(rawName: static string,
                           funcKind: static FormulaKind): untyped =

--- a/src/datamancer/gencase.nim
+++ b/src/datamancer/gencase.nim
@@ -65,7 +65,9 @@ proc getInnerType*(n: NimNode, last = newEmptyNode()): NimNode =
       result = n
   of nnkBracketExpr:
     let n0s = n[0].strVal.normalize
-    if n0s notin ["tensor", "seq", "typedesc", "openarray"]:
+    if n0s == "array": # for arrays the type is the last child node
+      result = n[^1]
+    elif n0s notin ["tensor", "seq", "typedesc", "openarray"]:
       result = n
     else:
       result = n[1].getInnerType

--- a/src/datamancer/value.nim
+++ b/src/datamancer/value.nim
@@ -119,6 +119,14 @@ proc `%~`*[T: ref object](x: T): Value =
   else:
     result = %~(x[])
 
+type
+  ScalarLike* = concept x
+    x.float is float
+
+proc `%~`*[T: ScalarLike](x: T): Value =
+  result = newVObject()
+  result[$T] = %~ x.float
+
 proc toObject*(s: seq[(string, Value)]): Value =
   ## converts the given sequence to an object
   ## This is only used to store the result of the `groups` iterator as a


### PR DESCRIPTION
Minor cleanup of the macro logic code and removal of dead code as well as some improvements:

- `genColumn` -> `defColumn`
- `toDf` now works with generic arguments as long as a matching column type is defined

Changelog:
```
* v0.3.3
- define =ScalarLike= concept to match types that can be converted to
  =float= via =.float= for e.g. units to have a =%~= Value conversion
  for them
- minor cleanup of macro logic
- rename =genColumn= to =defColumn=
- =toDf= now supports assignment of generic arguments as well, as long
  as the column types required have been generated already.
- =defColumn= now generates all combinations of the given types
- fixes some issues with =unionType= getting confused
- makes =toColumn= work correctly with =array=  
```