### PR TITLE
Further generic refinements

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,8 @@
+* v0.3.4
+- fix issues with =toDf= if only single argument given (with and
+  without string names) not setting DF length / raising CT error
+- add =to= option to convert type of data frame
+- some more internal macro logic cleanup  
 * v0.3.3
 - define =ScalarLike= concept to match types that can be converted to
   =float= via =.float= for e.g. units to have a =%~= Value conversion

--- a/playground/non_generic_generics.nim
+++ b/playground/non_generic_generics.nim
@@ -1,19 +1,24 @@
-import unchained, measuremancer
-
 import macros
 import arraymancer
-import datamancer # / [column, value]
+import datamancer
 
-#patchColumn(Tensor[Measurement[float]])
-import tables, sets # not needed if not called from here `patchDataFrame`
 
+# for testing here
+import unchained, measuremancer
+
+
+## Put the overloadable enums into your `nim.cfg`!
 {.experimental: "overloadableEnums".}
 
-proc makeCol[T](s: seq[T]) =
-  var c = toColumn(s.toTensor)
-  echo pretty(c)
+proc `%~`[T](x: Measurement[T]): Value =
+  result = %~ ($x)
+  # or
+  #result = newVobject()
+  #result["val"] = %~ x.value
+  #result["uncer"] = %~ x.error
+  # depending on if one wants it only for printing or more. Former
+  # is better to parse back
 
-#var t = toTensor(@[2.kg])
 defColumn(KiloGram)
 defColumn(Measurement[float])
 block:
@@ -34,30 +39,32 @@ block:
   c[0] = 1.5 ± 0.2
   echo c
 
+
+# to test type logic works in a generic:
+proc makeCol[T](s: seq[T]) =
+  var c = toColumn(s.toTensor)
+  echo pretty(c)
+
 # good, also works in a generic
 let x = @[1.0 ± 0.1, 2.0 ± 0.5]
 makeCol(x)
 
 echo "================================================================================"
-#patchDataFrame(Tensor[KiloGram])
+
+# define a function using the `dfFn` macro that takes a `DF` to deduce the
+# required input / return type of the formula
 let df = seqsToDf({"x" : [1,2,3]})
 let fn = dfFn(df, f{float -> KiloGram: "y" ~ (`x` * `x`).kg})
 echo typeof(fn)
 
 defUnit(kg²)
-#genTypeEnum(KiloGram²)
-#type kg2Col = patchColumn(KiloGram²)
 defColumn(Meter)
-#genTypeEnum(Meter)
-#type mCol = patchColumn(Meter)
 
-# needs multi generics. to be impl'd next
-#let dfNM = dfN.mutate(f{KiloGram -> KiloGram²: "kg2" ~ `kg` * `kg`})
-
-
+# more examples of what's possible
 let dfN = extendDataFrame(df, "kg", @[3.kg, 1.kg, 2.kg])
 echo dfN.pretty(precision = 10)
 
+# sorting works
 echo dfN.arrange("kg", SortOrder.Descending).pretty(precision = 10)
 echo dfN.arrange("kg", SortOrder.Ascending).pretty(precision = 10)
 
@@ -66,8 +73,6 @@ let fn2 = dfFn(dfN, f{KiloGram -> KiloGram²: "kg2" ~ `kg` * `kg`})
 echo typeof(fn2)
 #
 defColumn(KiloGram, Meter)
-##genTypeEnum(KiloGram, Meter)
-##type ttCol = patchColumn(KiloGram, Meter)
 let dfNM = extendDataFrame(dfN, "meter", @[1.m, 2.m, 3.m])
 echo dfNM.pretty(precision = 10)
 
@@ -78,6 +83,17 @@ echo dfNM.mutate(dfFn(dfNM, f{float: "kgtofoat" ~ idx(`kg`, KiloGram).float}))
 echo dfNM.mutate2(f{float: "kgtofoat" ~ idx(`kg`, KiloGram).float})
 
 
+block:
+  # `to` can be used to change DF type
+  doAssert df is DataFrame
+  let dfAsKg = df.to(DataTable[colType(KiloGram)])
+  doAssert type(dfAsKg) is DataTable[colType(KiloGram)]
+  # or
+  let dfAsKg2 = df.to(colType(KiloGram))
+  doAssert type(dfAsKg2) is DataTable[colType(KiloGram)]
+
+# complex types work (as long as they have simple fields, nothing
+# further needed)
 type
   Foo = object
     x: string
@@ -85,13 +101,45 @@ type
 proc `<`(f1, f2: Foo): bool = f1.val < f2.val
 defColumn(Foo)
 # accumulating types works to call mutate w/o df arg
-var dFoo = colType(Foo).newDataTable()
-dFoo["bar"] = @[Foo(x: "hello", val: 1.1), Foo(x: "world", val: 100.5)]
-dFoo = dFoo.mutate(f{Foo -> float: "values" ~ `bar`.val})
-echo dFoo.pretty(precision = 30)
+let fooSeq = @[Foo(x: "hello", val: 1.1), Foo(x: "world", val: 100.5)]
+
+block:
+  var dFoo = colType(Foo).newDataTable()
+  dFoo["bar"] = fooSeq
+  dFoo = dFoo.mutate(f{Foo -> float: "values" ~ `bar`.val})
+  echo dFoo.pretty(precision = 30)
 
 # extend simply by accumulating types
 ## WARNING: generating a column for a type that is an alias may cause problems!
 defColumn(KiloGram²)
-let df2 = df.mutate(f{int: "kg²" ~ `x`.kg²})
-echo df2
+block:
+  let df2 = df.mutate(f{int: "kg²" ~ `x`.kg²})
+  echo df2
+
+block:
+  # can construct using `toDf` call
+  let df2 = toDf(fooSeq)
+  echo df2
+
+block:
+  # still works with two
+  let y = @[1, 2]
+  let df2 = toDf(fooSeq, y)
+  echo df2
+
+block:
+  # also with a single named argument
+  let df2 = toDf({"x" : fooSeq})
+  echo df2
+
+block:
+  # and with Measurement[float]
+  let df2 = toDf({"x" : x})
+  echo df2
+
+
+block:
+  # and of course mixed
+  let y = @[1, 2]
+  let df2 = toDf({"x" : x, "y" : y})
+  echo df2

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -468,6 +468,14 @@ proc convertDataFrame*[C: ColumnLike; U](df: DataTable[C], dtype: typedesc[U]): 
     for k in keys(df):
       result[k] = toColumn(unionType(C, U), df[k])
 
+proc to*[C: ColumnLike; U: ColumnLike](df: DataTable[C], _: typedesc[U]): DataTable[U] =
+  ## Converts the given input DF from column type `C` to `U`
+  result = df.convertDataFrame(U)
+
+proc to*[C: ColumnLike; U: ColumnLike](df: DataTable[C], _: typedesc[DataTable[U]]): DataTable[U] =
+  ## Converts the given input DF from column type `C` to `U`
+  result = df.convertDataFrame(U)
+
 proc extendDataFrame*[C: ColumnLike; U](df: DataTable[C], key: string, arg: U): auto =
   ## Given a type that is not a normal DF type, returns a new DF type that can store
   ## it and puts it as `key`

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -482,13 +482,21 @@ proc assignAdjust[T](df: var DataFrame, name: string, s: T) =
   asgn(df, name, col)
   df.len = max(df.len, col.len)
 
-proc assignAdjustDataTable[C: ColumnLike; T](df: DataTable[C], name: string, s: T): auto =
+proc assignAdjustDataTable[C: ColumnLike; T: not (seq | openArray | Tensor)](df: DataTable[C], name: string, s: T): auto =
   ## If applicable, assigns `s` as a column to `df` and adjusts the length
   ## Might error at CT if type is not storable
   let col = unionType(C, T).toColumn s
   result = convertDataFrame(df, unionType(C, T))
   asgn(result, name, col)
-  df.len = max(result.len, col.len)
+  result.len = max(result.len, col.len)
+
+proc assignAdjustDataTable[C: ColumnLike; T](df: DataTable[C], name: string, s: seq[T] | openArray[T] | Tensor[T]): auto =
+  ## If applicable, assigns `s` as a column to `df` and adjusts the length
+  ## Might error at CT if type is not storable
+  let col = unionType(C, T).toColumn s
+  result = convertDataFrame(df, unionType(C, T))
+  asgn(result, name, col)
+  result.len = max(result.len, col.len)
 
 proc maybeToDf[T](s: T, name = ""): DataFrame =
   ## Attempts to convert the given typed argument to a valid `DataFrame`.

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -498,7 +498,7 @@ proc assignAdjustDataTable[C: ColumnLike; T](df: DataTable[C], name: string, s: 
   asgn(result, name, col)
   result.len = max(result.len, col.len)
 
-proc maybeToDf[T](s: T, name = ""): DataFrame =
+proc maybeToDf[T](s: T, name = ""): auto =
   ## Attempts to convert the given typed argument to a valid `DataFrame`.
   ## If one of a few known types are found, dispatches to the correct procedure.
   ## Else attempts to generate a new `DataFrame` using `assignAdjust`, which may
@@ -512,8 +512,7 @@ proc maybeToDf[T](s: T, name = ""): DataFrame =
   elif T is OrderedTable[string, seq[Value]]:
     result = valTabToDf(s)
   else:
-    result = newDataFrame()
-    assignAdjust(result, name, s)
+    result = assignAdjustDataTable(newDataFrame(), name, s)
 
 macro toTab*(args: varargs[untyped]): untyped =
   ## Performs conversion of the untyped arguments to a `DataFrame`.

--- a/src/datamancer/gencase.nim
+++ b/src/datamancer/gencase.nim
@@ -30,8 +30,7 @@ proc columnToTypes*(s: string): seq[string] =
   result = s.split("|").filterIt(it.len > 0 and it notin DtypesAll)
 
 proc columnToTypes*(n: NimNode): seq[string] =
-  doAssert n.kind in {nnkSym, nnkIdent}
-  var r = n.strVal
+  var r = n.nodeRepr
   result = columnToTypes(r)
 
 proc genCombinedTypeStr*(types: seq[string]): string =


### PR DESCRIPTION
Some small improvements that go a long way:

```nim
* v0.3.4
- fix issues with =toDf= if only single argument given (with and
  without string names) not setting DF length / raising CT error
- add =to= option to convert type of data frame
- some more internal macro logic cleanup  
```