### PR TITLE
Bind `items` for sets, fix ref issue for `filter` with constant columns

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,7 @@
+* v0.3.5
+- fix reference semantics bugs for constant columns for =filter= calls
+- fix issue with =gather= in files that do not import =sets= by
+  binding the =items= iterator in the scope  
 * v0.3.4
 - fix issues with =toDf= if only single argument given (with and
   without string names) not setting DF length / raising CT error

--- a/datamancer.nimble
+++ b/datamancer.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.4"
+version       = "0.3.5"
 author        = "Vindaar"
 description   = "A dataframe library with a dplyr like API"
 license       = "MIT"

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -2152,6 +2152,9 @@ proc gather*[C: ColumnLike](df: DataTable[C], cols: varargs[string],
     doAssert dfRes["Class", string] == ["A", "A", "A", "B", "B", "B", "C", "C", "C"].toTensor
     doAssert dfRes["Num", int] == [1, 8, 0, 3, 4, 0, 5, 7, 2].toTensor
 
+  # bind `sets.items` so we do not need to export `sets`
+  bind sets.items
+
   result = C.newDataTable(df.ncols)
   let remainCols = getKeys(df).toHashSet.difference(cols.toHashSet)
   let newLen = cols.len * df.len
@@ -2170,7 +2173,8 @@ proc gather*[C: ColumnLike](df: DataTable[C], cols: varargs[string],
     result.asgn(key, toColumn keyTensor)
     result.asgn(value, toColumn valTensor)
   # For remainder of columns, just use something like `repeat`!, `stack`, `concat`
-  for rem in remainCols:
+  # Note: explicit `items` call necessary, otherwise our `bind` does not work
+  for rem in items(remainCols):
     withNativeDtype(df[rem]): ## XXX: this might convert to colObject?
       let col = df[rem].toTensor(dtype)
       var fullCol = newTensorUninit[dtype](newLen)

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1203,7 +1203,8 @@ proc filterImpl[C: ColumnLike; T; U: seq[int] | Tensor[int]](resCol: var C, col:
 proc filter[C: ColumnLike; U: seq[int] | Tensor[int]](col: C, filterIdx: U): C =
   ## perform filterting of the given column `key`
   if col.kind == colConstant: # just return a "shortened" constant tensor
-    result = col
+    result = col.clone() # cloning a constant column is cheap. Otherwise we modify `col` via
+                         # reference semantics!
     result.len = filterIdx.len
   else:
     withNativeDtype(col):
@@ -1692,6 +1693,7 @@ proc mutateImpl[C: ColumnLike](df: var DataTable[C], fns: varargs[Formula[C]],
 
 proc mutateInplace*[C: ColumnLike; U](df: var DataTable[C], fns: varargs[Formula[U]]) =
   ## Inplace variasnt of `mutate` below.
+
   case df.kind
   of dfGrouped:
     var dfs = newSeq[DataTable[C]]()


### PR DESCRIPTION
Two minor fixes:

```
* v0.3.5
- fix reference semantics bugs for constant columns for =filter= calls
- fix issue with =gather= in files that do not import =sets= by
  binding the =items= iterator in the scope
```

The latter fixes the issue raised in https://github.com/SciNim/getting-started/pull/49 and https://github.com/SciNim/getting-started/pull/50.