### PR TITLE
Refactor `toHtml` to access raw HTML from `showBrowser`

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,5 @@
+* v0.3.8
+- refactor =toHtml= out of =showBrowser= to access raw generated HTML table
 * v0.3.7
 - fix regression for =bool= columns, by handling =ntyBool= in
   =gencase=. Fixes the ggplotnim CI, as noticed by https://github.com/Vindaar/ggplotnim/pull/151.

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -778,7 +778,7 @@ proc toHtml*[C: ColumnLike](df: DataTable[C], tmpl = ""): string =
     body.add "\n</tr>"
     inc idx
   body.add "</tbody>"
-  result = tmpl % body
+  result = tmpl % (header & body)
 
 proc showBrowser*[C: ColumnLike](
   df: DataTable[C], fname = "df.html", path = getTempDir(), toRemove = false,
@@ -792,8 +792,8 @@ proc showBrowser*[C: ColumnLike](
   ## Note: the HTML generation is not written for speed at this time. For very large
   ## dataframes expect bad performance.
   let tmpl = if htmlTmpl.len > 0: htmlTmpl else: HtmlTmpl
-  let page = tmpl % [fname, df.toHtml()]
   let fname = path / fname
+  let page = tmpl % [fname, df.toHtml()]
   writeFile(fname, page)
   openDefaultBrowser(fname)
   if toRemove:

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -496,7 +496,9 @@ b,,foo
     let c = [4, 5, 6]
     let df = toDf(a, b, c)
     check df.toHtml == """<table>
-  <tbody><tr>
+  <thead>
+<tr><th> Index </th><th> a <br><br> int </th><th> b <br><br> int </th><th> c <br><br> int </th></tr>
+</thead><tbody><tr>
 <td>0</td><td>1</td><td>3</td><td>4</td>
 </tr><tr>
 <td>1</td><td>2</td><td>4</td><td>5</td>

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -490,6 +490,22 @@ b,,foo
     check df["(Name) Additional name if exists"].kind == colObject
     check df["(Name) Additional name if exists", Value][0] == null()
 
+  test "`toHtml`":
+    let a = [1, 2, 3]
+    let b = [3, 4, 5]
+    let c = [4, 5, 6]
+    let df = toDf(a, b, c)
+    check df.toHtml == """<table>
+  <tbody><tr>
+<td>0</td><td>1</td><td>3</td><td>4</td>
+</tr><tr>
+<td>1</td><td>2</td><td>4</td><td>5</td>
+</tr><tr>
+<td>2</td><td>3</td><td>5</td><td>6</td>
+</tr></tbody>
+</table>
+"""
+
 suite "DataTable tests":
 
   test "`toDf` is no-op for DF":


### PR DESCRIPTION
Provide access to `toHtml` to have the raw `<table>` string from a dataframe.