### PR TITLE
degensym identifiers in toDf

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,5 @@
+* v0.3.9
+- =toDf= now degensyms identifiers so the name of the column is the same as the variable name also in templates.
 * v0.3.8
 - refactor =toHtml= out of =showBrowser= to access raw generated HTML table
 * v0.3.7

--- a/src/datamancer/ast_utils.nim
+++ b/src/datamancer/ast_utils.nim
@@ -43,3 +43,12 @@ proc combinations*(s: seq[NimNode]): seq[seq[NimNode]] =
     sNoX.delete(s.find(x))
     result.add combinations(sNoX)
   result = result.deduplicate()
+
+proc degensymTree*(n: NimNode): NimNode =
+  case n.kind
+  of nnkIdent, nnkSym:
+    result = ident(n.strVal.split("`gensym")[0])
+  else:
+    result = n.copy()
+    for i in 0 ..< n.len:
+      result[i] = degensymTree(n[i])

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -549,7 +549,7 @@ macro toTab*(args: varargs[untyped]): untyped =
       # Dispatch to `maybeToDf`
       return nnkBlockStmt.newTree(
         newEmptyNode(),
-        nnkCall.newTree(bindSym("maybeToDf"), arg, arg.toStrLit)
+        nnkCall.newTree(bindSym("maybeToDf"), arg, degensymTree(arg).toStrLit)
       )
     else:
       error("If only single argument it has to be an ident, symbol, call or command, " &

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -572,7 +572,7 @@ macro toTab*(args: varargs[untyped]): untyped =
       result.add quote do:
         var `tmp` = `asgnSym`(`lastTmp`, `nameCh`, `valCh`)
     else:
-      let aName = a.toStrLit
+      let aName = degensymTree(a).toStrLit
       result.add quote do:
         var `tmp` = `asgnSym`(`lastTmp`, `aName`, `a`)
     lastTmp = tmp

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -596,6 +596,17 @@ suite "DataTable tests":
     check "y" in df
     check df["y", string] == ["a", "b", "c"].toTensor
 
+  test "`toDf` works in template":
+    template foo() =
+      let x = @[1, 2, 3]
+      let y = @[1, 2, 3]
+      let df = toDf(x)
+      check "x" in df
+      let df2 = toDf(x, y)
+      check "x" in df2
+      check "y" in df2
+    foo()
+
   test "Creation of DFs from seqs":
     let a = [1, 2, 3]
     let b = [3, 4, 5]


### PR DESCRIPTION
Previously, when using `toDf` inside a template, the column could be named things like ```x`gensym``` which  is undesirable.

Do you want me to bump the nimble version as well? 