### PR TITLE
Implements lifting `col` reference nodes from a formula body 

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,5 +1,16 @@
 * v0.3.9
-- =toDf= now degensyms identifiers so the name of the column is the same as the variable name also in templates.
+- =toDf= now degensyms identifiers so the name of the column is the
+  same as the variable name also in templates (PR #45 by @hugogranstrom)
+- implement lifting out nodes in formulas that perform calculations on
+  full columns to avoid the extreme performance penalty of writing
+  something like ~f{"foo" ~ `x` + sum(col("y"))}~ where previously the
+  calculation of the sum would have been performed in line in the
+  loop. Now these are lifted out of the loop body and assigned to a
+  single ~let~ variable that is injected instead
+- add ~maxLines~ option to CSV parser, useful to only read the first N
+  lines
+- fix extraction of ~idx/col~ references in ~nnkCall~ arguments
+- fix type determination for procedures with default arguments of type ~bool~
 * v0.3.8
 - refactor =toHtml= out of =showBrowser= to access raw generated HTML table
 * v0.3.7

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -1,8 +1,8 @@
 import arraymancer/tensor
-import std / [sugar, math, strformat, tables, macros, strutils]
+import std / [sugar, strformat, tables, macros, strutils]
 import value
 
-from sequtils import allIt, mapIt
+from sequtils import allIt, anyIt, mapIt
 
 import ast_utils
 export ast_utils
@@ -42,7 +42,7 @@ const TypeNames = CacheTable"ColTypeNames"
 const TypeImpls = CacheTable"ColTypeImpls"
 const TypeToEnumType = CacheTable"TypeToEnumType"
 
-import algorithm, sugar, sequtils
+import sugar
 
 proc genColNameStr*(types: seq[string]): string =
   result = "Column" & genCombinedTypeStr(types)

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -306,7 +306,6 @@ macro checkSymbolIsValid(n: untyped): untyped =
     else:
       false
 
-proc isPureTree(n: NimNode): bool
 proc extractSymbols(n: NimNode): seq[NimNode] =
   if n.isPureTree:
     return @[n]
@@ -701,17 +700,6 @@ proc findType(n: NimNode, numArgs: int): PossibleTypes =
   ## possibly add special types
   possibleTypes.maybeAddSpecialTypes(n)
   result = possibleTypes
-
-proc isPureTree(n: NimNode): bool =
-  ## checks if this node tree is a "pure" tree. That means it does ``not``
-  ## contain any column references
-  result = true
-  if n.nodeIsDf or n.nodeIsDfIdx:
-    return false
-  for ch in n:
-    result = isPureTree(ch)
-    if not result:
-      return
 
 proc getTypeIfPureTree(tab: Table[string, NimNode], n: NimNode, numArgs: int): PossibleTypes =
   let lSym = buildName(n)

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -599,7 +599,13 @@ proc determineTypeFromProc(n: NimNode, numArgs: int): Option[ProcType] =
       var typ: NimNode
       case pArg[numP].kind
       of nnkEmpty:
-        typ = pArg[pArg.len - 1].getType # use the default values type
+        let lastCh = pArg[pArg.len - 1]
+        case lastCh.kind
+        of nnkIdent:
+          if lastCh.strVal in ["false", "true"]: typ = ident"bool"
+          else: error("Node " & $(lastCh.repr) & " is an identifier for which we don't understand the type.")
+        else:
+          typ = lastCh.getType # use the default values type
       else: # else param has a specific type
         typ = pArg[pArg.len - 2].toStrType # use the arguments type as a type
       for j in 0 ..< numP: # now add a type for *each* of the possible N arguments of the same type

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -559,7 +559,6 @@ proc countArgs(n: NimNode): tuple[args, optArgs: int] =
 func isTensorType(n: NimNode): bool =
   n[0].kind in {nnkSym, nnkIdent} and n[0].strVal == "Tensor"
 
-import sugar
 proc typeAcceptable(n: NimNode): bool =
   case n.kind
   of nnkIdent, nnkSym:

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -1303,6 +1303,7 @@ proc compileFormula(n: NimNode, fullNode = false, df: NimNode = newEmptyNode()):
       typeHintNode = typeHintNode[1]
       typeHint = typeHintNode.parseTypeHint
     node = extractCall(node, "loop")[1][0]
+    fct.fullFormula = true # indicate this is a full formula, to not lift nodes
   else:
     typeHint = parseTypeHint(node)
   let tilde = recurseFind(node,

--- a/src/datamancer/formulaExp.nim
+++ b/src/datamancer/formulaExp.nim
@@ -1,7 +1,7 @@
 import macros, sequtils, strformat, options, sets, tables, algorithm, strutils
 import formulaNameMacro
 
-import column, value
+import value
 
 type
   AssignKind* = enum


### PR DESCRIPTION
This represents a huge performance improvement for naively writtin formulas that act element wise, but contain a computation of a full column. Instead of repeating the computation for each element, we now lift it out of the loop body, assign it to a `let`, which takes the place of the previous calculation.

Further contains some misc bug fixes to formulas where replacements were not done if a column reference appeared in a later argument of a call & if a procedure was used with a default argument of type `bool`.

Finally, adds a `maxLines` argument to the CSV parser, to only read up to that many lines.