### PR TITLE
Org table export, ref semantics bug fix and misc more

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,10 @@
+* v0.3.10
+- add ~toOrgTable~ to convert a DF into an Org style table
+- fixes a reference semantic bug when slicling a DF containing a
+  constant column, e.g. by using ~head~ or ~tail~ (or manually)
+- small improvements to non generic generics (make them usable for
+  ~filter~ if used with ~dfFn~ for example)
+- memory optimize construction of ~groupMap~ in ~group_by~ call
 * v0.3.9
 - =toDf= now degensyms identifiers so the name of the column is the
   same as the variable name also in templates (PR #45 by @hugogranstrom)

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1057,7 +1057,7 @@ proc assignStack*[C: ColumnLike](dfs: seq[DataTable[C]]): DataTable[C] =
     inc lengths, df.len
   # 2. generate output columns of correct type and length
   for k in df0.getKeys():
-    result[k] = C.newColumnLike(df0[k].kind, lengths)
+    result[k] = C.newColumnLike(df0[k], lengths)
     # 2a. if column is constant, already assign its value
     if df0[k].kind == colConstant:
       result[k].cCol = df0[k].cCol
@@ -1240,7 +1240,7 @@ proc applyFilterFormula[C: ColumnLike](df: DataTable[C], fn: Formula[C]): C =
         "return boolean value, but " & $fn.valKind & ". Only boolean reducing formulae " &
         "are supported in `filter`.")
     let scaleVal = fn.fnS(df)
-    result = constantColumn(scaleVal.toBool, df.len)
+    result = C.constantColumn(scaleVal.toBool, df.len)
   else:
     raise newException(FormulaMismatchError, "Given formula " & $fn.name & " is of unsupported kind " &
       $fn.kind & ". Only reducing `<<` and mapping `~` formulas are supported in `filter`.")
@@ -1272,7 +1272,7 @@ proc filterImpl[C: ColumnLike](df: DataTable[C], conds: varargs[Formula[C]]): Da
   ## Does not differentiate between grouped and ungrouped inputs (done in
   ## exported `filter` below).
   result = C.newDataTable(df.ncols)
-  var filterIdx = newColumn(colBool)
+  var filterIdx = C.newColumnLike(colBool)
   for c in conds:
     if filterIdx.kind == colBool and filterIdx.len > 0:
       # combine two tensors

--- a/src/datamancer/gencase.nim
+++ b/src/datamancer/gencase.nim
@@ -180,12 +180,12 @@ proc bracketToSeq*(types: NimNode): seq[NimNode] =
 func enumFieldName*(s: string): string =
   var s = s
   s.removePrefix("Column")
-  result = "gk" & s.capitalizeAscii
+  result = "gk" & s # .capitalizeAscii
 
 func genericFieldName*(s: string): string =
   var s = s
   s.removePrefix("Column")
-  result = "g" & s.capitalizeAscii
+  result = "g" & s # .capitalizeAscii
 
 proc getEnumField*(typ: string): NimNode =
   if typ in EnumFieldNames:

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -812,3 +812,25 @@ proc showBrowser*[C: ColumnLike](
     # be there when the browser is finally open. Thus default is to keep the file
     sleep(1000)
     removeFile(fname)
+
+proc toOrgTable*[C: ColumnLike](df: DataTable[C], precision = 4, emphStrNumber = true): string =
+  ## Converts the given DF to a table formatted in Org syntax. Note that the
+  ## whitespace alignment is left up to Org mode. Just <tab> on the table in Org
+  ## mode to fix it.
+  const sep = "|"
+  let keys = df.getKeys()
+  let header = "| " & keys.join(" | ") & " |\n"
+  let line   = "|" & toSeq(0 ..< keys.len).mapIt("----").join("|") & "|\n"
+  ## symbol marking the header line, e.g. `#`
+  var data = newStringOfCap(df.len * 8) # for some reserved space
+  var idx = 0
+  for row in df:
+    idx = 0
+    data.add $sep
+    for x in row:
+      if idx > 0:
+        data.add $sep
+      data.add pretty(x, precision = precision, emphStrNumber = emphStrNumber)
+      inc idx
+    data.add $sep & "\n"
+  result = header & line & data


### PR DESCRIPTION
```
* v0.3.10
- add ~toOrgTable~ to convert a DF into an Org style table
- fixes a reference semantic bug when slicling a DF containing a
  constant column, e.g. by using ~head~ or ~tail~ (or manually)
- small improvements to non generic generics (make them usable for
  ~filter~ if used with ~dfFn~ for example)
- memory optimize construction of ~groupMap~ in ~group_by~ call
```