### PR TITLE
Use contains from stdlib for CacheTable when available

### DIFF
--- a/src/datamancer/ast_utils.nim
+++ b/src/datamancer/ast_utils.nim
@@ -29,9 +29,13 @@ proc replaceSymsByIdents*(ast: NimNode): NimNode =
   result = inspect(ast)
 
 import macrocache
-proc contains*(t: CacheTable, key: string): bool =
-  for k, val in pairs(t):
-    if k == key: return true
+
+when not declared(macrocache.contains):
+  proc contains*(t: CacheTable, key: string): bool =
+    for k, val in pairs(t):
+      if k == key: return true
+else:
+  export contains
 
 from sequtils import deduplicate
 proc combinations*(s: seq[NimNode]): seq[seq[NimNode]] =


### PR DESCRIPTION
I'm working on adding `contains` to `std/macrocache` in https://github.com/nim-lang/Nim/pull/21304 but the CI fails for this package since its already defined.

This just puts it behind a check so the original will still be used if unavailable