### PR TITLE
Minor IO, formula improvements

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,12 @@
+* v0.3.13
+- [io] add ~emphStrNumber~ arg to ~writeCsv~, ~pretty~ to disable
+  highlighting of strings that look like numbers via explicit ~"~
+- do not lift control flow out of loop bodies even if they do not
+  touch DF colums / indices
+- improve error message for ~add~ of two DataFrames, prints the
+  mismatching columns
+- fix Column conversion to string column from ~char~ input
+- add ~item~ to retrieve the single element of a ~Column~ and ~Tensor~ 
 * v0.3.12
 - replace all ~doAssert~ calls that really should be exceptions by
   exceptions so that ~--panics:on~ is saner. Fixes issue #51

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -240,7 +240,7 @@ proc toColumn*[C: ColumnLike; T](_: typedesc[C], t: Tensor[T]): C =
                     len: t.size)
   elif T is string or T is char:
     result = C(kind: colString,
-               sCol: t.asType(string),
+               sCol: t.map_inline($x),
                len: t.size)
   elif T is Value:
     result = C(kind: colObject,

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1037,7 +1037,12 @@ proc add*[C: ColumnLike](df: var DataTable[C], dfToAdd: DataTable[C]) =
     discard
   else:
     if df.getKeys.sorted != dfToAdd.getKeys.sorted:
-       raise newException(ValueError, "All keys must match to add data frames!")
+      let s1 = df.getKeys().toHashSet()
+      let s2 = dfToAdd.getKeys().toHashSet()
+      bind sets.items
+      let diff = symmetricDifference(s1, s2)
+      raise newException(ValueError, "All keys must match to add data frames. The following columns are " &
+        "present in one DF, but not the other: " & $diff)
     df = bind_rows([("", df), ("", dfToAdd)])
 
 proc assignStack*[C: ColumnLike](dfs: seq[DataTable[C]]): DataTable[C] =

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1829,7 +1829,7 @@ proc rename*[C: ColumnLike](df: DataTable[C], cols: varargs[Formula[C]]): DataTa
     doAssert "foo" in dfRes
     doAssert "y" in dfRes
 
-  result = df
+  result = df.shallowCopy()
   for fn in cols:
     if fn.kind == fkAssign:
       result[fn.lhs] = df[fn.rhs.toStr]

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -785,7 +785,8 @@ template add*[C: ColumnLike](df: var DataTable[C], args: varargs[untyped]): unty
   let tup = varargsToTuple(args)
   df.add(tup)
 
-proc pretty*[C: ColumnLike](df: DataTable[C], numLines = 20, precision = 4, header = true): string =
+proc pretty*[C: ColumnLike](df: DataTable[C], numLines = 20, precision = 4, header = true,
+                            emphStrNumber = true): string =
   ## Converts the first `numLines` of the input `DataFrame df` to a string table.
   ##
   ## If the `numLines` argument is negative, will print all rows of the data frame.
@@ -825,7 +826,7 @@ proc pretty*[C: ColumnLike](df: DataTable[C], numLines = 20, precision = 4, head
   for i in 0 ..< num:
     result.add align($i, idxAlign)
     for k in keys(df):
-      let element = pretty(df[k, i], precision = precision)
+      let element = pretty(df[k, i], precision = precision, emphStrNumber = emphStrNumber)
       if element.len < alignBy - 1:
         result.add align(element,
                          alignBy)

--- a/src/datamancer/formula.nim
+++ b/src/datamancer/formula.nim
@@ -603,6 +603,7 @@ proc determineTypeFromProc(n: NimNode, numArgs: int): Option[ProcType] =
         of nnkIdent:
           if lastCh.strVal in ["false", "true"]: typ = ident"bool"
           else: error("Node " & $(lastCh.repr) & " is an identifier for which we don't understand the type.")
+        of nnkDotExpr: discard # cannot deduce a type properly
         else:
           typ = lastCh.getType # use the default values type
       else: # else param has a specific type

--- a/src/datamancer/formulaExp.nim
+++ b/src/datamancer/formulaExp.nim
@@ -391,6 +391,12 @@ proc isPureTreeCol*(n: NimNode, dirtyNodes: seq[NimNode]): bool =
     if not result:
       return
 
+proc isControlFlow(n: NimNode): bool =
+  ## XXX: add remaining. Which are applicable though?
+  ## The idea here is to *not* consider a node for lifting out of
+  ## a loop, as that would break the code.
+  result = n.kind in {nnkIfStmt, nnkIfExpr, nnkElifExpr, nnkElifBranch, nnkElseExpr}
+
 proc isPureOrColAccess*(n: NimNode, dirtyNodes: var seq[NimNode]): LiftTreeKind =
   ## Checks if the given node is either a pure tree or only contains full
   ## column accesses. If that is the case, we can lift it out of the
@@ -420,7 +426,7 @@ proc isPureOrColAccess*(n: NimNode, dirtyNodes: var seq[NimNode]): LiftTreeKind 
       result = lkBreak
     else:
       result = lkLift
-  elif n.isPureTreeCol(dirtyNodes):
+  elif n.isPureTreeCol(dirtyNodes) and not n.isControlFlow():
     ## we break if an ident, as we don't need to lift out individual idents.
     ## In fact this would also lift things like `<`, `notin` etc.
     if n.kind in {nnkNone, nnkEmpty, nnkIdent, nnkSym, nnkType} + nnkLiterals: result = lkBreak

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -707,7 +707,7 @@ proc readCsvAlt*(fname: string,
   s.close()
 
 proc writeCsv*[C: ColumnLike](df: DataTable[C], filename: string, sep = ',', header = "",
-                              precision = 4, emphStrNumber = true) =
+                              precision = 8, emphStrNumber = true) =
   ## writes a DataFrame to a "CSV" (separator can be changed) file.
   ## `sep` is the actual separator to be used. `header` indicates a potential
   ## symbol marking the header line, e.g. `#`
@@ -815,7 +815,7 @@ proc showBrowser*[C: ColumnLike](
     sleep(1000)
     removeFile(fname)
 
-proc toOrgTable*[C: ColumnLike](df: DataTable[C], precision = 4, emphStrNumber = true): string =
+proc toOrgTable*[C: ColumnLike](df: DataTable[C], precision = 8, emphStrNumber = true): string =
   ## Converts the given DF to a table formatted in Org syntax. Note that the
   ## whitespace alignment is left up to Org mode. Just <tab> on the table in Org
   ## mode to fix it.

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -707,7 +707,7 @@ proc readCsvAlt*(fname: string,
   s.close()
 
 proc writeCsv*[C: ColumnLike](df: DataTable[C], filename: string, sep = ',', header = "",
-               precision = 4) =
+                              precision = 4, emphStrNumber = true) =
   ## writes a DataFrame to a "CSV" (separator can be changed) file.
   ## `sep` is the actual separator to be used. `header` indicates a potential
   ## symbol marking the header line, e.g. `#`
@@ -722,7 +722,7 @@ proc writeCsv*[C: ColumnLike](df: DataTable[C], filename: string, sep = ',', hea
     for x in row:
       if idx > 0:
         data.add $sep
-      data.add pretty(x, precision = precision)
+      data.add pretty(x, precision = precision, emphStrNumber = emphStrNumber)
       inc idx
     data.add "\n"
   writeFile(filename, data)


### PR DESCRIPTION
Changelog:

```
* v0.3.13
  - [io] add ~emphStrNumber~ arg to ~writeCsv~, ~pretty~ to disable
    highlighting of strings that look like numbers via explicit ~"~
  - do not lift control flow out of loop bodies even if they do not
    touch DF colums / indices
  - improve error message for ~add~ of two DataFrames, prints the
    mismatching columns
  - fix Column conversion to string column from ~char~ input
  - add ~item~ to retrieve the single element of a ~Column~ and ~Tensor~
```