### PR TITLE
Minor improvements

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -6,7 +6,9 @@
 - improve error message for ~add~ of two DataFrames, prints the
   mismatching columns
 - fix Column conversion to string column from ~char~ input
-- add ~item~ to retrieve the single element of a ~Column~ and ~Tensor~ 
+- add ~item~ to retrieve the single element of a ~Column~ and ~Tensor~
+- allow tilde =~= in paths for ~readCsv~
+- add optional ~serialize~ submodule to serialize to / from HDF5 files    
 * v0.3.12
 - replace all ~doAssert~ calls that really should be exceptions by
   exceptions so that ~--panics:on~ is saner. Fixes issue #51

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,11 @@
+* v0.3.14
+- add optional ~serialize~ submodule to serialize to / from HDF5 files    
+- allow tilde =~= in paths for ~readCsv~
+- add ~rows~ iterator to get rows of DF as single row DF
+- add ~[]~ with single int index to get single row of DF
+- add ~dropNaN~ helper to remove rows of DF that contain NaNs
+- minor fixes for regressions appearing in newer nim (duplicate case &
+  generic type resolution issue)
 * v0.3.13
 - [io] add ~emphStrNumber~ arg to ~writeCsv~, ~pretty~ to disable
   highlighting of strings that look like numbers via explicit ~"~
@@ -7,8 +15,6 @@
   mismatching columns
 - fix Column conversion to string column from ~char~ input
 - add ~item~ to retrieve the single element of a ~Column~ and ~Tensor~
-- allow tilde =~= in paths for ~readCsv~
-- add optional ~serialize~ submodule to serialize to / from HDF5 files    
 * v0.3.12
 - replace all ~doAssert~ calls that really should be exceptions by
   exceptions so that ~--panics:on~ is saner. Fixes issue #51

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -537,7 +537,7 @@ template withNative*[C: ColumnLike](c: C, idx: int,
     withCaseStmt(c, gk, C):
       let `valName` {.inject.} = c.gk[idx]
       body
-  of colNone, colGeneric: raise newException(ValueError, "Accessed column is empty!")
+  of colNone: raise newException(ValueError, "Accessed column is empty!")
 
 template withNativeDtype*[C: ColumnLike](c: C, body: untyped): untyped =
   case c.kind

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -21,6 +21,8 @@ export formula
 import formulaNameMacro
 export formulaNameMacro
 
+export math # for `classify` among others
+
 const ValueNull* = Value(kind: VNull)
 
 import ast_utils

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -282,7 +282,7 @@ proc `[]=`*[C: ColumnLike](df: var DataTable[C], k: string, col: C) {.inline.} =
     raise newException(ValueError, "Given column length of " & $col.len &
       " does not match DF length of: " & $df.len & "!")
 
-proc `[]=`*[C: ColumnLike; T: SomeNumber | string | bool](df: var DataTable[C], k: string, t: T) {.inline.} =
+proc `[]=`*[C: ColumnLike; T: SomeNumber | string | bool | Value](df: var DataTable[C], k: string, t: T) {.inline.} =
   ## Assigns a scalar `t` as a constant column to the `DataFrame`.
   runnableExamples:
     var df = toDf({"x" : @[1,2,3]})

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1172,8 +1172,8 @@ iterator groups*[C: ColumnLike](df: DataTable[C], order = SortOrder.Ascending): 
   # get all columns by which we group in a seq
   let cols = keys.mapIt(dfArranged[it])
 
-  proc buildClassLabel(df: DataTable[C], keys: seq[string],
-                       idx: int): seq[(string, Value)] =
+  proc buildClassLabel[C: ColumnLike](df: DataTable[C], keys: seq[string],
+                                      idx: int): seq[(string, Value)] =
     result = newSeq[(string, Value)](keys.len)
     for j, key in keys:
       result[j] = (key, df[key][idx, Value])

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -644,6 +644,10 @@ iterator items*[C: ColumnLike](df: DataTable[C]): Value =
     row.assignRow(df, i)
     yield row
 
+iterator rows*[C: ColumnLike](df: DataTable[C]): DataFrame =
+  for i in 0 ..< df.len:
+    yield df[i]
+
 iterator values*[C: ColumnLike](df: DataTable[C], cols: varargs[string]): Tensor[Value] {.inline.} =
   ## Yields all columns `cols` of `DataFrame df` as `Tensor[Value]` rows.
   ##

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -222,6 +222,15 @@ proc `[]`*[C: ColumnLike; U, V](df: DataTable[C], rowSlice: HSlice[U, V]): DataT
   # add 1, because it's an ``inclusive`` slice!
   result.len = (b - a) + 1
 
+proc `[]`*[C: ColumnLike](df: DataTable[C], row: int): DataTable[C] =
+  ## Returns the `row` as a data frame with a single element.
+  let keys = getKeys(df)
+  result = C.newDataTable(df.ncols)
+  for k in keys:
+    withNative(df[k], row, val):
+      result[k] = toColumn val
+  result.len = 1
+
 proc `[]`*[C: ColumnLike; U](df: DataTable[C], key: string, dtype: typedesc[U]): Tensor[U] =
   ## Returns the column `key` as a Tensor of type `dtype`.
   ##

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -671,7 +671,7 @@ proc readCsv*(fname: string,
   if fname.startsWith("http://") or fname.startsWith("https://"):
     return readCsvFromUrl(fname, sep=sep, header=header, skipLines=skipLines,
                           toSkip=toSkip, colNames=colNames)
-
+  let fname = fname.expandTilde()
   result = newDataFrame()
   var ff = memfiles.open(fname)
   var lineCnt = 0

--- a/src/datamancer/serialize.nim
+++ b/src/datamancer/serialize.nim
@@ -1,0 +1,47 @@
+# Simple H5 serialization of data frames and tensors
+
+from std / os import `/`, extractFilename
+from std / strutils import replace
+import nimhdf5
+import ./dataframe, ./column
+
+proc toH5*[T](h5f: H5File, x: Tensor[T], name = "", path = "/") =
+  ## Stores the given arraymancer `Tensor` in the given H5 file using the
+  ## shape info to construct an equivalent dataset.
+  let dset = h5f.create_dataset(path / name,
+                                @(x.shape), # 1D, so use length
+                                T)
+  when T is KnownSupportsCopyMem:
+    dset.unsafeWrite(x.toUnsafeView(), x.size.int)
+  else:
+    dset[dset.all] = x.toSeq1D
+
+proc toH5*(h5f: H5File, x: DataFrame, name = "", path = "/") =
+  ## Stores the given datamancer `DataFrame` as in the H5 file.
+  ## This is done by constructing a group for the dataframe and then adding
+  ## each column as a 1D dataset.
+  ##
+  ## Alternatively we could also store it as a composite datatype, but that is less
+  ## efficient for reading individual columns.
+  let grp = path / name
+  echo "Generating group ", grp
+  discard h5f.create_group(grp)
+  for k in getKeys(x):
+    withNativeTensor(x[k], val):
+      when typeof(val) isnot Tensor[Value]:
+        h5f.toH5(val, k.replace("/", "|"), grp)
+      else:
+        echo "[WARNING]: writing object column " & $k & " as string values!"
+        h5f.toH5(val.valueTo(string), k.replace("/", "|"), grp)
+
+proc fromH5*(h5f: H5File, res: var DataFrame, name = "", path = "/") =
+  ## Stores the given datamancer `DataFrame` as in the H5 file.
+  ## This is done by constructing a group for the dataframe and then adding
+  ## each column as a 1D dataset.
+  ##
+  ## Alternatively we could also store it as a composite datatype, but that is less
+  ## efficient for reading individual columns.
+  let grp = h5f[(path / name).grp_str]
+  for dataset in items(grp):
+    withDset(dataset):
+      res[dset.name.extractFilename()] = dset


### PR DESCRIPTION
```
* v0.3.14
- add optional ~serialize~ submodule to serialize to / from HDF5 files    
- allow tilde =~= in paths for ~readCsv~
- add ~rows~ iterator to get rows of DF as single row DF
- add ~[]~ with single int index to get single row of DF
- add ~dropNaN~ helper to remove rows of DF that contain NaNs
- minor fixes for regressions appearing in newer nim (duplicate case &
  generic type resolution issue)
```