### PR TITLE
Improve `count` to allow multiple args, fix a possible segfault

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.3.15
+- fix potential segfault when calling ~pretty~ on ~nil~ DF
+- allow ~count~ to take multiple arguments to group by and count
 * v0.3.14
 - add optional ~serialize~ submodule to serialize to / from HDF5 files    
 - allow tilde =~= in paths for ~readCsv~

--- a/changelog.org
+++ b/changelog.org
@@ -1,6 +1,7 @@
 * v0.3.15
 - fix potential segfault when calling ~pretty~ on ~nil~ DF
 - allow ~count~ to take multiple arguments to group by and count
+- add ~equal~ procedure for Columns and DataFrames for comparison of values  
 * v0.3.14
 - add optional ~serialize~ submodule to serialize to / from HDF5 files    
 - allow tilde =~= in paths for ~readCsv~

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -1114,6 +1114,19 @@ proc clone*[C: ColumnLike](c: C): C =
       result.gk = c.gk.clone()
   of colNone: discard
 
+proc equal*[C: ColumnLike](c1, c2: C): bool =
+  ## Equality of two `Columns` by equality of all elements.
+  ## Note: float values are compared exactly!
+  if c1.kind != c2.kind:
+    result = false
+  elif c1.len != c2.len:
+    result = false
+  else:
+    result = true
+    withNativeDtype(c1):
+      for i in 0 ..< c1.len:
+        if c1[i, dtype] != c2[i, dtype]: return false
+
 proc map*[T; U](c: Column, fn: (T -> U)): Column =
   ## Maps a given column given `fn` to a new column.
   ## Because `Column` is a variant type, an untyped mapping function

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -2069,8 +2069,10 @@ proc summarize*[C: ColumnLike](df: DataTable[C], fns: varargs[Formula[C]]): Data
       result.asgn(k, toNativeColumn vals)
       result.len = vals.len
 
-proc count*[C: ColumnLike](df: DataTable[C], col: string, name = "n"): DataTable[C] =
-  ## Counts the number of elements per type in `col` of the data frame.
+proc count*[C: ColumnLike](df: DataTable[C], col: openArray[string], name = "n"): DataTable[C] =
+  ## Counts the number of elements per type in `col` of the data frame. It may be
+  ## a single column or multiple. Each column simply implies a `group_by` that
+  ## column.
   ##
   ## The counts are stored in a new column given by `name`.
   ##
@@ -2099,6 +2101,10 @@ proc count*[C: ColumnLike](df: DataTable[C], col: string, name = "n"): DataTable
     result.asgn(k, toNativeColumn vals)
   result.asgn(name, toColumn counts)
   result.len = idx
+
+proc count*[C: ColumnLike](df: DataTable[C], col: string, name = "n"): DataTable[C] =
+  ## Overload of the above for a single string argument.
+  result = df.count([col], name)
 
 proc setDiff*[C: ColumnLike](df1, df2: DataTable[C], symmetric = false): DataTable[C] =
   ## Returns a `DataFrame` with all elements in `df1` that are ``not`` found in

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -815,6 +815,7 @@ proc pretty*[C: ColumnLike](df: DataTable[C], numLines = 20, precision = 4, head
   ## `pretty` is called by `$` with the default parameters.
   # TODO: need to improve printing of string columns if length of elements
   # more than `alignBy`.
+  if df == nil: return "DataFrame(nil)"
 
   ## XXX: should columns of different types have different default widths? e.g. float being
   ## at least 9 chars, ints X, strings Y ?

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -384,6 +384,28 @@ proc asgn*[C: ColumnLike; U](df: var DataTable[C], k: string, col: U) {.inline.}
   ## XXX: error at CT if not fit? modify?
   df.data[k] = toColumn col #, T)
 
+proc equal*[C: ColumnLike](df1, df2: DataTable[C]): bool =
+  ## Equality operation of two data frames based on data equality, not
+  ## the same ref.
+  ##
+  ## We do not use `==` to allow `==` to remain a reference equality including
+  ## comparing with `nil`.
+  if df1 == nil and df2 == nil: result = true
+  elif df1 == nil or df2 == nil: result = false
+  elif df1.kind != df2.kind: result = false
+  elif df1.len != df2.len: result = false
+  else:
+    let k1 = getKeys(df1)
+    let k2 = getKeys(df2)
+    if k1 != k2: result = false
+    else:
+      result = true
+      for k in k1:
+        if not equal(df1[k], df2[k]): return false
+      if df1.kind == dfGrouped:
+        # group map can be compared using `OrderedTable` equality
+        result = df1.groupMap == df2.groupMap
+
 # ---------- Data frame construction from data ----------
 
 proc extendShortColumns*[C: ColumnLike](df: var DataTable[C]) =

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1238,11 +1238,11 @@ t_in_s,  C1_in_V,  C2_in_V,  type
                      "n" : [20, 10, 30, 10, 30] })
 
     ## Manual using `summarize`
-    check df.group_by(by=["A", "B"]).summarize(f{int: "n" << len(col("C")) }) == exp
+    check equal(df.group_by(by=["A", "B"]).summarize(f{int: "n" << len(col("C")) }), exp)
     ## First a single `group_by`, then `count`
-    check df.group_by("A").count("B") == exp
+    check equal(df.group_by("A").count("B"), exp)
     ## Using multiple columns in `count`
-    check df.count(["A", "B"]) == exp
+    check equal(df.count(["A", "B"]), exp)
 
   test "isNull":
     # tests removal of VNull elements in a column with VNull

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1230,6 +1230,20 @@ t_in_s,  C1_in_V,  C2_in_V,  type
         resDirectSet.incl (row["cyl"].toInt.int, row["n"].toInt.int)
       check resDirectSet == exp
 
+  test "Count - multiple columns":
+    let df = toDf({ "A" : concat(newSeqWith(30, 1), newSeqWith(30, 2), newSeqWith(40, 3)),
+                    "B" : concat(newSeqWith(20, 5), newSeqWith(50, 6), newSeqWith(30, 7)),
+                    "C" : toSeq(0 ..< 100) })
+    let exp = toDf({ "A": [1, 1, 2, 3, 3], "B" : [5, 6, 6, 6, 7],
+                     "n" : [20, 10, 30, 10, 30] })
+
+    ## Manual using `summarize`
+    check df.group_by(by=["A", "B"]).summarize(f{int: "n" << len(col("C")) }) == exp
+    ## First a single `group_by`, then `count`
+    check df.group_by("A").count("B") == exp
+    ## Using multiple columns in `count`
+    check df.count(["A", "B"]) == exp
+
   test "isNull":
     # tests removal of VNull elements in a column with VNull
     let x1 = toSeq(0 .. 100)


### PR DESCRIPTION
```
* v0.3.15
- fix potential segfault when calling ~pretty~ on ~nil~ DF
- allow ~count~ to take multiple arguments to group by and count
- add ~equal~ procedure for Columns and DataFrames for comparison of values  
```