### PR TITLE
`innerJoin` with variable arguments and `assignStack` misc.

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.3.16
+- handle empty datasets in ~assignStack~
+- add overload for ~innerJoin~ for more than two arguments  
 * v0.3.15
 - fix potential segfault when calling ~pretty~ on ~nil~ DF
 - allow ~count~ to take multiple arguments to group by and count

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1099,6 +1099,7 @@ proc assignStack*[C: ColumnLike](dfs: seq[DataTable[C]]): DataTable[C] =
   ## procedure is speeding up assignment for cases where we know this holds.
   if dfs.len == 0: return C.newDataTable()
   elif dfs.len == 1: return dfs[0]
+  let dfs = dfs.filterIt(it.getKeys().len > 0)
   let df0 = dfs[0]
   result = C.newDataTable(df0.getKeys().len)
   # 1. determine required lengths of final columns

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1992,7 +1992,9 @@ proc innerJoin*[C: ColumnLike](df1, df2: DataTable[C], by: string): DataTable[C]
         result[k].len = result.len
 
 proc innerJoin*[C: ColumnLike](dfs: varargs[DataTable[C]], by: string): DataTable[C] =
-  ## Inner join for more than two arguments
+  ## Inner join for more than two arguments. Performs the `innerJoin` operation on each
+  ## set of arguments after another. Does *not* optimize the order in  which the operations
+  ## are performed!
   if dfs.len == 0:
     result = newDataFrame()
   elif dfs.len == 1:

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1990,6 +1990,17 @@ proc innerJoin*[C: ColumnLike](df1, df2: DataTable[C], by: string): DataTable[C]
             result.asgn(k, toColumn(t[_ ..< result.len]))
         result[k].len = result.len
 
+proc innerJoin*[C: ColumnLike](dfs: varargs[DataTable[C]], by: string): DataTable[C] =
+  ## Inner join for more than two arguments
+  if dfs.len == 0:
+    result = newDataFrame()
+  elif dfs.len == 1:
+    result = dfs[0]
+  else:
+    result = innerJoin(dfs[0], dfs[1], by)
+    for i in 2 ..< dfs.len:
+      result = result.innerJoin(dfs[i], by)
+
 proc toHashSet*[T](t: Tensor[T]): HashSet[T] =
   ## Internal helper to convert a tensor to a `HashSet`
   for el in t:


### PR DESCRIPTION
```
* v0.3.16
- handle empty datasets in ~assignStack~
- add overload for ~innerJoin~ for more than two arguments
```