### PR TITLE
Parsing improvements and more misc stuff

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,11 @@
+* v0.3.18
+- add ~shuffle~ to shuffle a DF. Either using stdlib global RNG or
+  given RNG
+- add ~extend~ helpers for ~seq/Tensor/Column~ to add a single element
+  to any collection and return the extended version
+- throw custom ~OSError~ if CSV file cannot be read
+- add =%~= for ~(string, T)~ to construct a ~VObject~ Value
+- fix ~spread~ implementation if more keys are present
 * v0.3.17
 - handle DF construction from an empty seq or tensor
 - hotfix for ~assignStack~ fix of previous version

--- a/changelog.org
+++ b/changelog.org
@@ -1,4 +1,4 @@
-* v0.3.18
+* v0.4.0
 - add ~shuffle~ to shuffle a DF. Either using stdlib global RNG or
   given RNG
 - add ~extend~ helpers for ~seq/Tensor/Column~ to add a single element
@@ -6,6 +6,7 @@
 - throw custom ~OSError~ if CSV file cannot be read
 - add =%~= for ~(string, T)~ to construct a ~VObject~ Value
 - fix ~spread~ implementation if more keys are present
+- [IO] fix for space separated files with quoted fields as columns
 * v0.3.17
 - handle DF construction from an empty seq or tensor
 - hotfix for ~assignStack~ fix of previous version

--- a/changelog.org
+++ b/changelog.org
@@ -6,6 +6,11 @@
 - throw custom ~OSError~ if CSV file cannot be read
 - add =%~= for ~(string, T)~ to construct a ~VObject~ Value
 - fix ~spread~ implementation if more keys are present
+- correctly handle quoted fields in CSV files, fixes issue #58
+- add ~allowLineBreaks~ option to also allow for line breaks in quoted
+  fields. It's an optional option (despite being commonly useful for
+  files with quotes), because counting the lines is otherwise a useful
+  sanity check the parsing worked successfully.  
 - [IO] fix for space separated files with quoted fields as columns
 * v0.3.17
 - handle DF construction from an empty seq or tensor

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -1206,3 +1206,25 @@ proc lead*[C: ColumnLike](c: C, n = 1): C =
   ## Overload of the above for columns
   withNativeDtype(c):
     result = C.toColumn lead(c.toTensor(dtype), n)
+
+proc extend*[T](s: openArray[T], val: T): seq[T] =
+  ## Extends the given seq / array and returns a version with the element(s) added.
+  ## This is a single element version of `concat` if you wish.
+  result = @s
+  result.add val
+
+proc extend*[T](s: Tensor[T], val: T): Tensor[T] =
+  ## Extends the given seq / array and returns a version with the element(s) added.
+  ## This is a single element version of `concat` if you wish.
+  result = newTensorUninit[T](s.size)
+  for i in 0 ..< s.size:
+    result[i] = s[i]
+  result[result.size - 1] = val
+
+proc extend*[C: ColumnLike; T](s: C, val: T): ColumnLike =
+  ## Extends the given seq / array and returns a version with the element(s) added.
+  ## This is a single element version of `concat` if you wish.
+  result = newColumnLike(C, s.len + 1)
+  for i in 0 ..< s.len:
+    result[i] = s[i]
+  result[result.high] = val

--- a/src/datamancer/column.nim
+++ b/src/datamancer/column.nim
@@ -1009,6 +1009,8 @@ proc add*[C: ColumnLike](c1, c2: C): C =
       withCaseStmt(c1, gk, C):
         result = C.toColumn concat(c1.gk, c2.gk, axis = 0)
     of colNone: raise newException(ValueError, "Both columns are empty!")
+  elif c1.kind == colConstant or c2.kind == colConstant: # important to happen before next branch!
+    result = add(c1.constantToFull, c2.constantToFull)
   elif compatibleColumns(c1, c2):
     # convert both to float
     case c1.kind
@@ -1024,8 +1026,6 @@ proc add*[C: ColumnLike](c1, c2: C): C =
       # one of the two is constant and same type as the other
       # `constantToFull` is a no-op for the non-constant column
       result = add(c1.constantToFull, c2.constantToFull) # recurse on this proc
-  elif c1.kind == colConstant or c2.kind == colConstant:
-    result = add(c1.constantToFull, c2.constantToFull)
   else:
     # convert both columns to Value
     result = C.toColumn concat(c1.toObject.oCol, c2.toObject.oCol, axis = 0)

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1177,7 +1177,7 @@ proc compareRows[C: ColumnLike](cols: seq[C], i, j: int): bool =
     if not result: return false
 
 proc arrange*[C: ColumnLike](df: DataTable[C], by: varargs[string], order = SortOrder.Ascending): DataTable[C]
-iterator groups*[C: ColumnLike](df: DataTable[C], order = SortOrder.Ascending): (seq[(string, Value)], DataTable[C]) =
+iterator groups*[C: ColumnLike](df: DataTable[C], order = SortOrder.Ascending, sorted = false): (seq[(string, Value)], DataTable[C]) =
   ## Yields the subgroups of a grouped DataFrame `df` and the `(key, Value)`
   ## pairs that were used to create the subgroup.
   ##
@@ -1207,7 +1207,8 @@ iterator groups*[C: ColumnLike](df: DataTable[C], order = SortOrder.Ascending): 
   # sort by keys
   let keys = getKeys(df.groupMap)
   # arrange by all keys in ascending order
-  let dfArranged = df.arrange(keys, order = order)
+  let dfArranged = if sorted: df
+                   else: df.arrange(keys, order = order)
   # get all columns by which we group in a seq
   let cols = keys.mapIt(dfArranged[it])
 

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -2315,27 +2315,29 @@ proc spread*[C: ColumnLike; T](df: DataTable[C], namesFrom, valuesFrom: string,
   for c in newCols:
     result[c.toStr] = newColumn(df[valuesFrom].kind, dfOutlen)
   var idx = 0
+
   # 5. now group by *other* keys and get the `newCols` from each. That way each subgroup
   #   corresponds to *one row* in the output
   if restKeys.len > 0:
     # 6. for each sub df, walk all rows to get correct key/vals
     # NOTE: this is inefficient
-    for (tup, subDf) in groups(df.group_by(restKeys)):
+    for (tup, subDf) in groups(df.group_by(namesFrom)):
+      idx = 0
       for row in subDf:
         # NOTE: we could also extract the restKeys info from `tup`
         for col in restKeys:
           withNative(row[col], x):
-            result[col, idx] = x
+            result[col][idx] = x
         withNative(row[valuesFrom], x):
-          result[row[namesFrom].toStr, idx] = x
-      inc idx
+          result[row[namesFrom].toStr][idx] = x
+        inc idx
   else:
     # if there are no other keys, group by each class and fill the classes separately.
     for (tup, subDf) in groups(df.group_by(namesFrom)):
       idx = 0
       for row in subDf:
         withNative(row[valuesFrom], x):
-          result[row[namesFrom].toStr, idx] = x
+          result[row[namesFrom].toStr][idx] = x
         inc idx
 
 proc unique*[C: ColumnLike](c: C): C =

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -2311,8 +2311,8 @@ proc spread*[C: ColumnLike; T](df: DataTable[C], namesFrom, valuesFrom: string,
   # bind `items` here to make it available in calling scope without `import sets`
   bind items
   let newCols = toSeq(items(dfGrouped.groupMap[namesFrom]))
-  # 4. and length of resulting DF by getting class with most counts
-  let dfOutlen = df.count(namesFrom)["n", int].max
+  # 4. number of output: unique values in remaining columns
+  let dfOutlen = df.select(restKeys).unique().len
   # 5. create result DF from input column types
   for c in restKeys:
     result[c] = newColumn(df[c].kind, dfOutlen)

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -2478,6 +2478,34 @@ proc dropNaN*[C: ColumnLike](df: DataTable[C], cols: varargs[string],
     else:
       doAssert false, "This branch cannot happen!"
 
+from std/random import Rand, shuffle
+from std/sugar import dup
+proc shuffle*(df: DataFrame, rnd: var Rand): DataFrame =
+  ## Shuffles the input data frame using the given RNG
+  result = df.shallowCopy()
+  var idxs = toSeq(0 .. df.high)
+  rnd.shuffle(idxs)
+  result["Idx"] = idxs
+  result = result.arrange("Idx")
+  result.drop("Idx")
+
+proc shuffle*(df: DataFrame): DataFrame =
+  ## Shuffles the input data frame using the stdlib global RNG
+  result = df.shallowCopy()
+  result["Idx"] = toSeq(0 .. df.high).dup(shuffle())
+  result = result.arrange("Idx")
+  result.drop("Idx")
+
+proc randomHead*(df: DataFrame, head: int, rnd: var Rand): DataFrame =
+  ## Returns `head` elements of the input DataFrame after shuffling it,
+  ## using the given RNG
+  result = df.shuffle(rnd).head(min(head, df.len))
+
+proc randomHead*(df: DataFrame, head: int): DataFrame =
+  ## Returns `head` elements of the input DataFrame after shuffling it,
+  ## using the stdlib global RNG.
+  result = df.shuffle().head(min(head, df.len))
+
 func evaluate*[C: ColumnLike](node: Formula[C]): Value =
   ## Tries to return a single `Value` from a `Formula`.
   ##

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1080,7 +1080,7 @@ proc add*[C: ColumnLike](df: var DataTable[C], dfToAdd: DataTable[C]) =
       bind sets.items
       let diff = symmetricDifference(s1, s2)
       raise newException(ValueError, "All keys must match to add data frames. The following columns are " &
-        "present in one DF, but not the other: " & $diff)
+        "present in one DF, but not the other: " & $diff & ". Mutable df: " & $df & " and dfToAdd: " & $dfToAdd)
     df = bind_rows([("", df), ("", dfToAdd)])
 
 proc assignStack*[C: ColumnLike](dfs: openArray[DataTable[C]]): DataTable[C] =

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -437,7 +437,7 @@ proc strTabToDf*(t: OrderedTable[string, seq[string]]): DataFrame =
     if v.len > 0:
       # TODO: CLEAN UP
       var maybeNumber = v[0].isNumber
-      var maybeInt = v[0].isInt
+      var maybeInt = v[0].isInt('"')
       if maybeNumber and maybeInt:
         # try as int
         try:

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -331,7 +331,7 @@ proc `[]=`*[C: ColumnLike; T](df: var DataTable[C], k: string, idx: int, val: T)
 
   # we depend on df.len != df.data.len in `innerJoin` among others. This is a somewhat
   # unsafe procedure!
-  assert df.data[k].len > idx, "Invalid index " & $idx & " for DF column of length " & $df.data.len
+  assert df.data[k].len > idx, "Invalid index " & $idx & " for DF column of length " & $df.data[k].len
   when T is float:
     df.data[k].fCol[idx] = val
   elif T is int:

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1083,7 +1083,7 @@ proc add*[C: ColumnLike](df: var DataTable[C], dfToAdd: DataTable[C]) =
         "present in one DF, but not the other: " & $diff)
     df = bind_rows([("", df), ("", dfToAdd)])
 
-proc assignStack*[C: ColumnLike](dfs: seq[DataTable[C]]): DataTable[C] =
+proc assignStack*[C: ColumnLike](dfs: openArray[DataTable[C]]): DataTable[C] =
   ## Returns a data frame built as a stack of the data frames in the sequence.
   ##
   ## This is a somewhat unsafe procedure as it trades performance for safety. It's

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -1877,7 +1877,7 @@ proc rename*[C: ColumnLike](df: DataTable[C], cols: varargs[Formula[C]]): DataTa
   result = df.shallowCopy()
   for fn in cols:
     if fn.kind == fkAssign:
-      result[fn.lhs] = df[fn.rhs.toStr]
+      result[fn.lhs] = result[fn.rhs.toStr]
       # remove the column of the old name
       result.drop(fn.rhs.toStr)
     else:

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -2301,40 +2301,49 @@ proc spread*[C: ColumnLike; T](df: DataTable[C], namesFrom, valuesFrom: string,
       doAssert dfRes["C", int] == [0, 5, 7, 2].toTensor
 
   result = C.newDataTable()
-  # 1. determine new columns from all unique values in `namesFrom`
-  let dfGrouped = df.group_by(namesFrom)
+  # 1. find remaining keys
+  let restKeys = df.getKeys().filterIt(it != namesFrom and it != valuesFrom)
+  # 2. sort DF by keys for where we take names from *and* all other columns
+  #  important to get same order in all sub DFs
+  let dfS = df.arrange(concat(@[namesFrom], restKeys))
+  # 3. determine new columns from all unique values in `namesFrom`
+  var dfGrouped = dfS.group_by(namesFrom)
   # bind `items` here to make it available in calling scope without `import sets`
   bind items
   let newCols = toSeq(items(dfGrouped.groupMap[namesFrom]))
-  # 2. find remaining keys
-  let restKeys = df.getKeys().filterIt(it != namesFrom and it != valuesFrom)
-  # 3. and length of resulting DF by getting class with most counts
+  # 4. and length of resulting DF by getting class with most counts
   let dfOutlen = df.count(namesFrom)["n", int].max
-  # 4. create result DF from input column types
+  # 5. create result DF from input column types
   for c in restKeys:
     result[c] = newColumn(df[c].kind, dfOutlen)
   for c in newCols:
     result[c.toStr] = newColumn(df[valuesFrom].kind, dfOutlen)
   var idx = 0
 
+  let remainNumber = dfS.count(restKeys).len
+  if remainNumber != dfOutlen:
+    raise newException(ValueError, "One or more of the remaining columns in the input DF not used " &
+      "as `namesFrom` or `valuesFrom` contains data not cleanly mapped to any name in `namesFrom`. Remaining keys:\n" &
+      "\t" & $restKeys & ". The groups: " & $df.count(restKeys) & " compared to number of classes " &
+      "based on `namesFrom`: " & $dfOutlen)
+
   # 5. now group by *other* keys and get the `newCols` from each. That way each subgroup
   #   corresponds to *one row* in the output
   if restKeys.len > 0:
     # 6. for each sub df, walk all rows to get correct key/vals
-    # NOTE: this is inefficient
-    for (tup, subDf) in groups(df.group_by(namesFrom)):
-      idx = 0
+    # Group by the *other* keys
+    dfGrouped = dfS.group_by(restKeys)
+    for (tup, subDf) in groups(dfGrouped):
       for row in subDf:
-        # NOTE: we could also extract the restKeys info from `tup`
         for col in restKeys:
           withNative(row[col], x):
             result[col][idx] = x
         withNative(row[valuesFrom], x):
           result[row[namesFrom].toStr][idx] = x
-        inc idx
+      inc idx
   else:
     # if there are no other keys, group by each class and fill the classes separately.
-    for (tup, subDf) in groups(df.group_by(namesFrom)):
+    for (tup, subDf) in groups(dfGrouped, sorted = true):
       idx = 0
       for row in subDf:
         withNative(row[valuesFrom], x):

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -392,6 +392,7 @@ template parseLine(data: ptr UncheckedArray[char], buf: var string,
     #if not inQuote:
     #  colStart = idx + 1
     inQuote = not inQuote
+    lastWasSep = false
   elif unlikely(inQuote):
     inc idx
     # skip ahead in case we start quote

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -673,17 +673,20 @@ proc readCsv*(fname: string,
                           toSkip=toSkip, colNames=colNames)
   let fname = fname.expandTilde()
   result = newDataFrame()
-  var ff = memfiles.open(fname)
-  var lineCnt = 0
-  for slice in memSlices(ff, delim = lineBreak, eat = eat):
-    if slice.size > 0:
-      inc lineCnt
+  try:
+    var ff = memfiles.open(fname)
+    var lineCnt = 0
+    for slice in memSlices(ff, delim = lineBreak, eat = eat):
+      if slice.size > 0:
+        inc lineCnt
 
-  ## we're dealing with ASCII files, thus each byte can be interpreted as a char
-  var data = cast[ptr UncheckedArray[char]](ff.mem)
-  result = readCsvTypedImpl(data, ff.size, lineCnt, sep, header, skipLines, maxLines, toSkip, colNames,
-                            skipInitialSpace, quote, maxGuesses, lineBreak, eat)
-  ff.close()
+    ## we're dealing with ASCII files, thus each byte can be interpreted as a char
+    var data = cast[ptr UncheckedArray[char]](ff.mem)
+    result = readCsvTypedImpl(data, ff.size, lineCnt, sep, header, skipLines, maxLines, toSkip, colNames,
+                              skipInitialSpace, quote, maxGuesses, lineBreak, eat)
+    ff.close()
+  except OSError:
+    raise newException(OSError, "Attempt to read CSV file: " & $fname & " failed. No such file or directory.")
 
 proc readCsvAlt*(fname: string,
                  sep = ',',

--- a/src/datamancer/serialize.nim
+++ b/src/datamancer/serialize.nim
@@ -26,6 +26,7 @@ proc toH5*(h5f: H5File, x: DataFrame, name = "", path = "/") =
   let grp = path / name
   echo "Generating group ", grp
   discard h5f.create_group(grp)
+  if x == nil: return # nothing to serialize!
   for k in getKeys(x):
     withNativeTensor(x[k], val):
       when typeof(val) isnot Tensor[Value]:

--- a/src/datamancer/value.nim
+++ b/src/datamancer/value.nim
@@ -256,21 +256,25 @@ func isNumber*(v: Value): bool =
       "objects of kind `VString`. Input is " & $v.kind)
   result = v.str.isNumber
 
-func isInt*(s: string): bool =
+func isInt*(s: string, quote: char): bool =
   ## simple "most likely int" check. If the string only contains digits and
   ## `_` we consider it an Int
-  s.allCharsInSet({'0' .. '9', '_'})
+  let s = s.strip(chars = {quote})
+  if s.allCharsInSet({'0' .. '9', '_'}):
+    result = true
+  elif s.normalize in ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]:
+    result = true
 
 func isBool*(s: string): bool =
   s == "true" or s == "false"
 
-func isInt*(v: Value): bool =
+func isInt*(v: Value, quote = '"'): bool =
   ## checks whether the string contained in `Value` is likely an integer
   ## For an `isFloat` equivalent see `isNumber`.
   if v.kind != VString:
     raise newException(ValueError, "`isInt` can only be checked for `Value` " &
       "objects of kind `VString`. Input is " & $v.kind)
-  result = v.str.isInt
+  result = v.str.isInt(quote)
 
 proc toFloat*(v: Value, allowNull: static bool = false): float =
   when not allowNull:

--- a/src/datamancer/value.nim
+++ b/src/datamancer/value.nim
@@ -139,6 +139,12 @@ proc `%~`*[T: ScalarLike](x: T): Value =
   result = newVObject()
   result[$T] = %~ x.float
 
+proc `%~`*[T](v: (string, T)): Value =
+  ## construct a `VObject` `Value`. Assumes that the 'key' is a string and
+  ## `T` can be converted via `%~`
+  result = newVObject()
+  result[v[0]] = %~ v[1]
+
 proc toObject*(s: seq[(string, Value)]): Value =
   ## converts the given sequence to an object
   ## This is only used to store the result of the `groups` iterator as a

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1041,7 +1041,7 @@ suite "DataTable tests":
       ## TODO: support NULL values instead of filling by default T(0)
     block:
       let data = """
-          Type          Septem            Line            Fake          ε_cut    FractionPass
+          Type          Septem            Line            Fake           ε_cut    FractionPass
       LineReal           false            true            Real               1          0.2204
       LineFake           false            true            Fake               1          0.8622
     SeptemReal            true           false            Real               1          0.2315
@@ -1051,14 +1051,17 @@ SeptemLineFake            true            true            Fake               1  
 """
       let df = parseCsvString(data, sep = ' ')
       let exp = """
-Type           Septem  Line   ε_cut     Real     Fake
-LineReal       false   true       1   0.2204   0.8622
-SeptemReal     true    false      1   0.2315   0.7255
-SeptemLineReal true    true       1   0.1368   0.7763
+          Type       Septem         Line        ε_cut         Real         Fake
+      LineFake        false         true            1            0       0.8622
+      LineReal        false         true            1       0.2204            0
+    SeptemFake         true        false            1            0       0.7763
+SeptemLineFake         true         true            1            0       0.7255
+SeptemLineReal         true         true            1       0.1368            0
+    SeptemReal         true        false            1       0.2315            0
 """
       let dfExp = parseCsvString(exp, sep = ' ')
       let dfRes = df.spread("Fake", "FractionPass")
-      check dfRes.len == 3
+      check dfRes.len == 6
       check dfRes.getKeys().len == 6
       check dfRes.getKeys() == dfExp.getKeys()
       check equal(dfRes, dfExp)

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1037,7 +1037,7 @@ suite "DataTable tests":
       for k in dfSpread.getKeys():
         check dfSpread[k].kind == colInt
       # easy column to check, all 1
-      check dfSpread["\"Release\"", int] == newTensorWith(19, 1)
+      check dfSpread["Release", int] == newTensorWith(19, 1)
       ## TODO: support NULL values instead of filling by default T(0)
     block:
       let data = """

--- a/tests/testParse.nim
+++ b/tests/testParse.nim
@@ -23,7 +23,7 @@ suite "`parseNumber` tests":
     initBuf()
     template checkInt(v: typed): untyped =
       toBuf($v)
-      let ret = buf.parseNumber(sep = ',',
+      let ret = buf.parseNumber(sep = ',', quote = '#',
                                 idxIn = 0,
                                 intBuf, floatBuf)
       check intBuf == v
@@ -50,7 +50,7 @@ suite "`parseNumber` tests":
     initBuf()
     template checkInt(str, val: typed, start: int): untyped =
       toBuf(str)
-      let ret = buf.parseNumber(sep = ',',
+      let ret = buf.parseNumber(sep = ',', quote = '#',
                                 idxIn = start,
                                 intBuf, floatBuf)
       check intBuf == val
@@ -75,7 +75,7 @@ suite "`parseNumber` tests":
     for i in 0 ..< 50:
       toBuf($i & "," & $i)
       let start = if i < 10: 1 else: 2
-      let ret = buf.parseNumber(sep = ',',
+      let ret = buf.parseNumber(sep = ',', quote = '#',
                                 idxIn = start,
                                 intBuf, floatBuf)
       check ret == rtNaN
@@ -84,7 +84,7 @@ suite "`parseNumber` tests":
     initBuf()
     template checkFloat(v: typed, class = fcNormal, retTyp = rtFloat): untyped =
       toBuf($v)
-      let ret = buf.parseNumber(sep = ',',
+      let ret = buf.parseNumber(sep = ',', quote = '#',
                                 idxIn = 0,
                                 intBuf, floatBuf)
       if class notin {fcNan, fcInf, fcNegInf}:
@@ -115,7 +115,7 @@ suite "`parseNumber` tests":
     initBuf()
     template checkFloat(str, val: typed, start: int, retTyp = rtFloat, class = fcNormal): untyped =
       toBuf(str)
-      let ret = buf.parseNumber(sep = ',',
+      let ret = buf.parseNumber(sep = ',', quote = '#',
                                 idxIn = start,
                                 intBuf, floatBuf)
       if class notin {fcNan, fcInf, fcNegInf}:
@@ -179,7 +179,7 @@ suite "`parseNumber` tests":
     initBuf()
     template checkFloat(str: typed, start: int, retTyp = rtFloat, class = fcNormal): untyped =
       toBuf(str)
-      let ret = buf.parseNumber(sep = ',',
+      let ret = buf.parseNumber(sep = ',', quote = '#',
                                 idxIn = start,
                                 intBuf, floatBuf)
       check ret == retTyp
@@ -214,7 +214,7 @@ suite "`parseNumber` tests":
     initBuf()
     template checkFloat(str: typed, start: int, retTyp = rtFloat, class = fcNormal): untyped =
       toBuf(str)
-      let ret = buf.parseNumber(sep = ',',
+      let ret = buf.parseNumber(sep = ',', quote = '#',
                                 idxIn = start,
                                 intBuf, floatBuf)
       check ret == retTyp


### PR DESCRIPTION
Some fixes to `spread` and adds  few helpers (see changelog). Mainly fixes issue #58 about parsing of CSV files with quoted fields (I hope fully).

Full changelog:

```
* v0.4.0
- add ~shuffle~ to shuffle a DF. Either using stdlib global RNG or
  given RNG
- add ~extend~ helpers for ~seq/Tensor/Column~ to add a single element
  to any collection and return the extended version
- throw custom ~OSError~ if CSV file cannot be read
- add =%~= for ~(string, T)~ to construct a ~VObject~ Value
- fix ~spread~ implementation if more keys are present
- correctly handle quoted fields in CSV files, fixes issue #58
- add ~allowLineBreaks~ option to also allow for line breaks in quoted
  fields. It's an optional option (despite being commonly useful for
  files with quotes), because counting the lines is otherwise a useful
  sanity check the parsing worked successfully.  
- [IO] fix for space separated files with quoted fields as columns
```