### PR TITLE
Update arraymancer dependency, remove `len`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [version-1-4, devel]
+        branch: [version-1-6, version-2-0, devel]
         target: [linux, macos, windows]
         include:
           - target: linux

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,9 @@
+* v0.4.1
+- remove our ~len~ for ~Tensor~ due to addition in arraymaner now
+  (update arraymancer dep to ~>= 0.7.28~)
+- improvement to formula logic to detect procedures with ~{.error:
+  "".}~ pragma usage and ignore them for type matching (necessary due
+  to forbidding e.g. ~+~ in arraymancer for ~Tensor + Scalar~ now)  
 * v0.4.0
 - add ~shuffle~ to shuffle a DF. Either using stdlib global RNG or
   given RNG

--- a/changelog.org
+++ b/changelog.org
@@ -11,6 +11,15 @@
  ~max(varargs[Tensor]]): Tensor~ type procedure in arraymancer, for
  some reason older Nim versions bind the symbol ~max~ fully to that
  ~varargs~ version. That breaks previous formulas.
+ In formulas using ~max~ (or similarly ~min~) it may also be necessary
+ to supply type hints, even if they were not required previously for
+ related reasons. E.g. replace:
+ ~f{ max(idx("a"), 2) }~
+ by
+ ~f{int: max(idx("a"), 2) }~
+ to indicate the column ~"a"~ should be treated as integers.
+ Given that this is fixed on Nim devel, I won't attempt a hacky
+ workaround. Please just update your Nim version or your formulas. :( 
 * v0.4.0
 - add ~shuffle~ to shuffle a DF. Either using stdlib global RNG or
   given RNG

--- a/changelog.org
+++ b/changelog.org
@@ -3,7 +3,14 @@
   (update arraymancer dep to ~>= 0.7.28~)
 - improvement to formula logic to detect procedures with ~{.error:
   "".}~ pragma usage and ignore them for type matching (necessary due
-  to forbidding e.g. ~+~ in arraymancer for ~Tensor + Scalar~ now)  
+  to forbidding e.g. ~+~ in arraymancer for ~Tensor + Scalar~ now)
+
+*Note*: If you are on Nim 1.6 or 2.0 (but not after) and you are using
+ a formula with ~max(c"foo")~ where ~foo~ is a column name, you will
+ have to replace that by ~max(col("foo"))~. Due to a new addition of a
+ ~max(varargs[Tensor]]): Tensor~ type procedure in arraymancer, for
+ some reason older Nim versions bind the symbol ~max~ fully to that
+ ~varargs~ version. That breaks previous formulas.
 * v0.4.0
 - add ~shuffle~ to shuffle a DF. Either using stdlib global RNG or
   given RNG

--- a/datamancer.nimble
+++ b/datamancer.nimble
@@ -11,7 +11,7 @@ srcDir        = "src"
 
 requires "nim >= 1.2.0"
 requires "https://github.com/Vindaar/seqmath >= 0.1.11"
-requires "arraymancer >= 0.7.1"
+requires "arraymancer >= 0.7.28"
 
 task test, "Run standard tests":
   exec "nim c -r tests/testDf.nim"

--- a/src/datamancer/dataframe.nim
+++ b/src/datamancer/dataframe.nim
@@ -121,12 +121,6 @@ proc shallowCopy*[C: ColumnLike](df: DataTable[C]): DataTable[C] =
 
 # ---------- General convenience helpers ----------
 
-func len*[T](t: Tensor[T]): int =
-  ## Helper proc for 1D `Tensor[T]` to return the length of the vector, which
-  ## corresponds to a length of a DF column.
-  assert t.rank == 1
-  result = t.size
-
 proc contains*[C: ColumnLike](df: DataTable[C], key: string): bool =
   ## Checks if the `key` names column in the `DataFrame`.
   result = df.data.hasKey(key)

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -1987,15 +1987,32 @@ suite "Formulas":
     ## This test is really only to test that the `mutate` formula shown here is
     ## actually compiled correctly into a mapping operation, with or without
     ## user given `~`
+    let mpgDf = readCsv("data/mpg.csv")
+    block WithName:
+      let df = mpgDf
+        .group_by("class")
+        .mutate(f{float -> float: "subMeanHwy" ~ idx(`cty`) + mean(df["hwy"])})
+        .arrange("class")
+      check df.len == 234
+      check df["subMeanHwy", float][0 ..< 5] == [40.8, 39.8, 40.8, 39.8, 39.8].toTensor
     block:
-      let df = readCsv("data/mpg.csv")
+      ## Check that it also works correctly without `idx`!
+      let df = mpgDf
         .group_by("class")
         .mutate(f{float -> float: "subMeanHwy" ~ `cty` + mean(df["hwy"])})
         .arrange("class")
       check df.len == 234
       check df["subMeanHwy", float][0 ..< 5] == [40.8, 39.8, 40.8, 39.8, 39.8].toTensor
     block:
-      let df = readCsv("data/mpg.csv")
+      ## And same with direct `col`
+      let df = mpgDf
+        .group_by("class")
+        .mutate(f{float -> float: "subMeanHwy" ~ `cty` + mean(col("hwy"))})
+        .arrange("class")
+      check df.len == 234
+      check df["subMeanHwy", float][0 ..< 5] == [40.8, 39.8, 40.8, 39.8, 39.8].toTensor
+    block NoName: ## without an explicit name
+      let df = mpgDf
         .group_by("class")
         .mutate(f{float -> float: `cty` + mean(df["hwy"])})
         .arrange("class")

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -11,6 +11,11 @@ proc almostEq(a, b: float, epsilon = 1e-8): bool =
   if not result:
     echo "Comparison failed: a = ", a, ", b = ", b
 
+template onlyDevel(body: untyped): untyped =
+  ## Used to disable some tests on older nim versions
+  when (NimMajor, NimMinor, NimPatch) >= (2, 1, 0):
+    body
+
 suite "Value":
   let
     v1 = %~ 1
@@ -210,9 +215,15 @@ suite "Formula":
     check h.val == %~ false
     check h.name == "(== (%~ tup.a) (%~ tup.b))"
 
-    let f2 = f{float: "min" << min(c"runTimes")}
-    check $f2 == "min" # LHS of formula
-    check f2.name == "(<< min (min runTimes))"
+    block:
+      let f2 = f{float: "min" << min(col("runTimes"))}
+      check $f2 == "min" # LHS of formula
+      check f2.name == "(<< min (min (col runTimes)))"
+    onlyDevel:
+      block:
+        let f2 = f{float: "min" << min(c"runTimes")}
+        check $f2 == "min" # LHS of formula
+        check f2.name == "(<< min (min runTimes))"
 
 
   test "Evaluate raw formula (no DF column dependency)":


### PR DESCRIPTION
Removes our custom `len` due to the arraymancer addition of it.

And a minor improvement to the formula logic, which now ignores any procedures, which use the `{.error.}` pragma for potential type matching.