### PR TITLE
Fix issue #65 by making identifiers unique

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,9 @@
+* v0.4.3
+- fix issue #65 where not enough identifier hygiene in formula macros
+  could cause CT errors if user variable of same name as column name
+  appeared and accented quoting was used
+- allow a title for the page in ~showBrowser~
+- add option to ~exclude~ columns when using ~fromH5~ serialization
 * v0.4.2
 Add experimental support for the JS backend!
 

--- a/src/datamancer/io.nim
+++ b/src/datamancer/io.nim
@@ -894,7 +894,7 @@ proc toHtml*[C: ColumnLike](df: DataTable[C], tmpl = ""): string =
 when not defined(js):
   proc showBrowser*[C: ColumnLike](
     df: DataTable[C], fname = "df.html", path = getTempDir(), toRemove = false,
-    htmlTmpl = "") =
+    htmlTmpl = "", title = "") =
     ## Displays the given DataFrame as a table in the default browser.
     ##
     ## `htmlTmpl` can be used as the HTML template of the page on which to print the
@@ -904,8 +904,10 @@ when not defined(js):
     ## Note: the HTML generation is not written for speed at this time. For very large
     ## dataframes expect bad performance.
     let tmpl = if htmlTmpl.len > 0: htmlTmpl else: HtmlTmpl
-    let fname = path / fname
-    let page = tmpl % [fname, df.toHtml()]
+    var titl = path / fname
+    if title.len > 0:
+       titl &= " - " & title
+    let page = tmpl % [titl, df.toHtml()]
     writeFile(fname, page)
     openDefaultBrowser(fname)
     if toRemove:

--- a/src/datamancer/serialize.nim
+++ b/src/datamancer/serialize.nim
@@ -44,5 +44,7 @@ proc fromH5*(h5f: H5File, res: var DataFrame, name = "", path = "/", exclude: se
   ## efficient for reading individual columns.
   let grp = h5f[(path / name).grp_str]
   for dataset in items(grp):
-    withDset(dataset):
-      res[dataset.name.extractFilename()] = dset
+    let col = dataset.name.extractFilename()
+    if col notin exclude:
+      withDset(dataset):
+        res[col] = dset

--- a/src/datamancer/serialize.nim
+++ b/src/datamancer/serialize.nim
@@ -35,7 +35,7 @@ proc toH5*(h5f: H5File, x: DataFrame, name = "", path = "/") =
         echo "[WARNING]: writing object column " & $k & " as string values!"
         h5f.toH5(val.valueTo(string), k.replace("/", "|"), grp)
 
-proc fromH5*(h5f: H5File, res: var DataFrame, name = "", path = "/") =
+proc fromH5*(h5f: H5File, res: var DataFrame, name = "", path = "/", exclude: seq[string] = @[]) =
   ## Stores the given datamancer `DataFrame` as in the H5 file.
   ## This is done by constructing a group for the dataframe and then adding
   ## each column as a 1D dataset.
@@ -45,4 +45,4 @@ proc fromH5*(h5f: H5File, res: var DataFrame, name = "", path = "/") =
   let grp = h5f[(path / name).grp_str]
   for dataset in items(grp):
     withDset(dataset):
-      res[dset.name.extractFilename()] = dset
+      res[dataset.name.extractFilename()] = dset

--- a/tests/testDf.nim
+++ b/tests/testDf.nim
@@ -2069,6 +2069,18 @@ suite "Formulas":
       let res = df.filter(f{bool: not `y`})
       check res["x", int] == [2].toTensor
 
+  test "Variables with same name as column names work with accent quotes":
+    # Previous to the fix of #65 this was not allowed
+    let df = toDf({ "x" : @[1, 2, 3, 4, 5], "y" : @["a", "b", "c", "d", "e"] })
+    let y = "e"
+    # check it compiles and leaves 3 elements
+    check df.filter(f{ `x` < 3 or `y` == y }).len == 3
+    # should of course also work with explicit `idx()` syntax
+    check df.filter(f{ `x` < 3 or idx("y") == y }).len == 3
+    # and for completeness manual type info is valid
+    check df.filter(f{ idx("x", int) < 3 or idx("y", string) == y }).len == 3
+
+
 suite "Formulas with object columns using convenience operators":
   test "int comparisons":
     let df = toDf({"x" : [%~ 1, %~ 2, %~ 3]})


### PR DESCRIPTION
Due to an oversight we were not modifying the identifiers used in the case of accent quoted identifiers at all. This is now done and to make sure no similar regressions happen, we now add a unique suffix to each identifier we produce. 

This PR also adds a couple of minor things that were still lying around:

```
* v0.4.3
- fix issue #65 where not enough identifier hygiene in formula macros
  could cause CT errors if user variable of same name as column name
  appeared and accented quoting was used
- allow a title for the page in ~showBrowser~
- add option to ~exclude~ columns when using ~fromH5~ serialization
```